### PR TITLE
fix: close prooflane browser proof gates (signed replay)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,14 +82,20 @@ jobs:
           sarif_file: .runtime-cache/artifacts/ci/trivy-results.sarif
           category: trivy
       - name: Repo doctor
+        env:
+          UIQ_DOCTOR_REPO_SKIP_REDUNDANT_GOVERNANCE: "1"
         run: bash scripts/lib/pnpm-safe.sh doctor:repo
       - name: Lint all
+        env:
+          UIQ_SKIP_SENSITIVE_SURFACE_GATE: "1"
         run: UIQ_CONTAINER_GATE_NAME=ci-quick-gate-lint bash scripts/lint-all.sh
       - name: Log quality
         run: node scripts/ci/check-log-quality.mjs
       - name: MCP contract check
         run: bash scripts/lib/pnpm-safe.sh mcp:check
       - name: Fast matrix
+        env:
+          UIQ_SUITE_ORCHESTRATOR_MCP_CONTRACT: "0"
         run: bash scripts/lib/pnpm-safe.sh test:matrix:fast
 
   required_ci_gate:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -37,6 +37,8 @@ jobs:
           corepack prepare "$(node -p "require('./package.json').packageManager")" --activate
       - name: Containerized nightly deterministic core
         env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
           UIQ_CONTAINER_GATE_SERVICE_OVERRIDE: ci-browser
           UIQ_CONTAINER_GATE_BUILD_OVERRIDE: ci-browser
           UIQ_CONTAINER_GATE_COMMAND_OVERRIDE: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -106,14 +106,20 @@ jobs:
           sarif_file: .runtime-cache/artifacts/ci/trivy-results.sarif
           category: trivy
       - name: Lint all
+        env:
+          UIQ_SKIP_SENSITIVE_SURFACE_GATE: "1"
         run: UIQ_CONTAINER_GATE_NAME=pr-quick-gate-lint bash scripts/lint-all.sh
       - name: Log quality
         run: node scripts/ci/check-log-quality.mjs
       - name: MCP contract check
         run: bash scripts/lib/pnpm-safe.sh mcp:check
       - name: frontend-e2e-behavior-suite
+        env:
+          UIQ_SUITE_ORCHESTRATOR_MCP_CONTRACT: "0"
         run: bash scripts/lib/pnpm-safe.sh test:matrix:fast
       - name: Run PR Profile
+        env:
+          UIQ_DOCTOR_REPO_SKIP_REDUNDANT_GOVERNANCE: "1"
         run: bash scripts/lib/pnpm-safe.sh doctor:repo
 
   pr_required_gate:

--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -55,12 +55,21 @@ restating those remote GitHub surfaces as freshly verified current state.
 - Generic in-repo skill packet at `docs/skills/prooflane-mcp/`
 - Release-ready docs, CI governance, and security gate surfaces
 
+## Companion Skill Host State
+
+- ClawHub listing for the companion skill packet is live at
+  `https://clawhub.ai/xiaojiou176/prooflane-mcp`
+- OpenHands/extensions remains `review-pending` via PR `#161`
+- Those receipts apply to `docs/skills/prooflane-mcp/` only; they do **not**
+  prove npm/PyPI publication, main-product marketplace listing, or hosted SaaS
+  availability
+
 ## Not Published Yet
 
 - npm package
 - PyPI package
 - Official plugin marketplace listing
-- Public Skills marketplace listing
+- Additional public Skills marketplace listings beyond the ClawHub companion packet
 - Separate starter bundle distribution
 - Public Docker image
 - Hosted multi-tenant SaaS claim

--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -12,16 +12,37 @@ reuse.
 - Public release channel:
   `https://github.com/xiaojiou176-open/ui-automation-control-plane/releases`
 
-## Live Now
+## Primary lane vs companion lanes
+
+- **Primary lane:** the Prooflane stress-lab front door, localhost-first
+  product path, and governed run flow
+- **Companion integration lane:** the repo-native MCP server in
+  `services/mcp-server/`
+- **Companion packet lane:** the generic in-repo skill packet under
+  `docs/skills/prooflane-mcp/`
+
+Important boundary:
+
+> companion MCP/package/skill status belongs to those surfaces only.
+> it does not turn Prooflane into a browser extension product, an already
+> listed marketplace package, or a hosted SaaS.
+
+## Repo-owned today
+
+- Localhost-first stress-lab product path
+- Governed run lane through `pnpm uiq run ...`
+- Repo-native MCP server through `pnpm mcp:start`
+- Public-safe guided demo and proof docs
+
+## Remote GitHub routes (audit-backed)
 
 - Public GitHub repository under `xiaojiou176-open`
 - GitHub Pages site
 - GitHub Issues and Discussions
-- Public release `Prooflane v0.1.0`
-- Localhost-first stress-lab product path
-- Governed run lane through `pnpm uiq run ...`
-- Repo-native MCP server through `pnpm mcp:start`
-- Generic in-repo skill scaffold at `docs/skills/prooflane-mcp/`
+- Public release route for `Prooflane v0.1.0`
+
+Use `docs/reference/public-readiness.md` and the latest audit artifacts before
+restating those remote GitHub surfaces as freshly verified current state.
 
 ## Ready In Repo, But Not Published As Separate Distributions
 
@@ -31,7 +52,7 @@ reuse.
   `pnpm dlx @uiq/mcp-server`
 - MCP integration docs and config snippets for Codex, Claude Code, OpenClaw,
   and other MCP-capable clients
-- Public-safe guided demo and proof-center docs
+- Generic in-repo skill packet at `docs/skills/prooflane-mcp/`
 - Release-ready docs, CI governance, and security gate surfaces
 
 ## Not Published Yet
@@ -62,6 +83,9 @@ It is truthful to say that:
 - the governed run and MCP surfaces exist today
 - the publish-ready MCP artifact target is `@uiq/mcp-server`
 - the planned CLI name is `prooflane-mcp`
+- MCP and skill packet surfaces are companion lanes, not the primary product
+  identity
+- Prooflane is browser-adjacent, but it is not a browser-extension product
 
 It is **not** truthful to say that:
 

--- a/INTEGRATIONS.md
+++ b/INTEGRATIONS.md
@@ -11,7 +11,7 @@ This page keeps the integration story truthful and compact.
 | MCP server | Live, repo-native | `pnpm mcp:start` |
 | MCP package shape | Publish-ready, not published | `@uiq/mcp-server` -> `prooflane-mcp` |
 | Codex / Claude Code / other MCP hosts | Supported through MCP config, not a marketplace listing | `docs/how-to/mcp-clients-setup.md` |
-| Generic skill scaffold | Ready in repo, not marketplace-published | `docs/skills/prooflane-mcp/SKILL.md` |
+| Companion skill packet | ClawHub live; OpenHands review-pending | `docs/skills/prooflane-mcp/SKILL.md` |
 
 ## What Does Not Exist Yet
 
@@ -20,7 +20,7 @@ This page keeps the integration story truthful and compact.
 | npm package | Not published |
 | PyPI package | Not published |
 | Official plugin marketplace listing | Not published |
-| Public Skills marketplace listing | Not published |
+| Additional public Skills marketplace listings beyond the companion ClawHub packet | Not published |
 | Public Docker image | Not published |
 | Separate starter bundle distribution | Not published |
 

--- a/README.md
+++ b/README.md
@@ -60,11 +60,13 @@ marketplace, and hosted lanes still stay in separate, claim-gated buckets.
   channel, Discussions, and issue templates are part of the current front-door
   route, but their current live state stays audit-backed.
 - **Ready but not live yet**: the publish-ready MCP package
-  `@uiq/mcp-server`, the planned `prooflane-mcp` CLI shape, and the companion
-  in-repo skill packet at `docs/skills/prooflane-mcp/`.
-- **Not published yet**: PyPI, npm registry distribution, plugin marketplaces,
-  public Skills registry listings, public Docker images, and hosted SaaS
-  distribution claims.
+  `@uiq/mcp-server` and the planned `prooflane-mcp` CLI shape.
+- **Companion skill host state**: the packet at `docs/skills/prooflane-mcp/`
+  is now listed live on ClawHub and still `review-pending` on
+  OpenHands/extensions; those receipts apply only to the companion skill lane.
+- **Not published yet**: PyPI, npm registry distribution, official plugin
+  marketplaces, additional public Skills registry listings beyond the ClawHub
+  companion packet, public Docker images, and hosted SaaS distribution claims.
 - **Audit rule**: use
   [docs/reference/public-readiness.md](./docs/reference/public-readiness.md)
   before restating live GitHub metadata, homepage, release presence, or branch

--- a/README.md
+++ b/README.md
@@ -19,6 +19,21 @@
 | First visible win | **Target-first experiment -> readable result** | A newcomer should get one clear result path before opening proof/governance depth. |
 | Deeper layer | **Governed proof + agent-ready workflows** | MCP, AI review, and release briefs stay behind the first experiment result instead of replacing the front door story. |
 
+## Primary Product vs Companion Surfaces
+
+Use this like a museum map:
+
+| Surface | Role | What it proves | What it must not be mistaken for |
+| --- | --- | --- | --- |
+| `README.md` + `docs/get-started.md` + the local stress-lab shell | primary product lane | Prooflane is an AI-native WebUI stress lab | a package listing, a browser extension, or a hosted SaaS proof |
+| `docs/proof-center.md` + `Advanced Review` story | deeper governed layer | proof, review, and AI summaries still exist behind the first result | the first-use front door |
+| `services/mcp-server/` + `docs/skills/prooflane-mcp/` | companion integration lane | MCP-capable clients can attach to the same governed runtime | the main product identity or proof that a marketplace/package listing already happened |
+
+In plain language:
+
+> browser-adjacent does not mean browser-extension product.
+> MCP-ready does not mean package-listed.
+
 ## Start with one visible win
 
 Choose the shortest honest path before you read the heavier engineering stack:
@@ -36,18 +51,24 @@ Choose the shortest honest path before you read the heavier engineering stack:
 
 ## Distribution Truth Today
 
-Prooflane is **distribution-ready on GitHub today**, but it is not claiming
-registry or marketplace distribution that has not happened yet.
+Prooflane already has a **public GitHub front door today**, but its package,
+marketplace, and hosted lanes still stay in separate, claim-gated buckets.
 
-- **Live now**: GitHub repository, GitHub Pages, release notes, Discussions,
-  issue templates, the localhost-first stress-lab path, governed runs, the
+- **Repo-owned now**: the localhost-first stress-lab path, governed runs, the
   repo-native MCP command `pnpm mcp:start`, and public-safe proof/demo docs.
+- **Remote GitHub routes exist**: the public repository, homepage, release
+  channel, Discussions, and issue templates are part of the current front-door
+  route, but their current live state stays audit-backed.
 - **Ready but not live yet**: the publish-ready MCP package
-  `@uiq/mcp-server`, the planned `prooflane-mcp` CLI shape, and the generic
-  in-repo Skill scaffold at `docs/skills/prooflane-mcp/`.
+  `@uiq/mcp-server`, the planned `prooflane-mcp` CLI shape, and the companion
+  in-repo skill packet at `docs/skills/prooflane-mcp/`.
 - **Not published yet**: PyPI, npm registry distribution, plugin marketplaces,
   public Skills registry listings, public Docker images, and hosted SaaS
   distribution claims.
+- **Audit rule**: use
+  [docs/reference/public-readiness.md](./docs/reference/public-readiness.md)
+  before restating live GitHub metadata, homepage, release presence, or branch
+  enforcement as fresh fact.
 - **Manual later**: custom GitHub social preview upload still belongs to
   GitHub Settings rather than a tracked repo action.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,20 +6,31 @@ you need more detail.
 
 ## Distribution Truth Today
 
-Prooflane is already publishable through **GitHub + GitHub Pages + public-safe
+Prooflane is already public through **GitHub + GitHub Pages + public-safe
 docs**, but it is not claiming package-registry or marketplace distribution
 that has not happened yet.
 
-- **Live now**: GitHub repository, GitHub Pages, Discussions, release notes,
-  MCP docs, public-safe guided demo, and proof docs.
+- **Repo-owned now**: MCP docs, public-safe guided demo, public proof docs, and
+  the localhost-first stress-lab path.
+- **Remote GitHub routes exist**: repository, homepage, Discussions, and
+  release surfaces remain audit-backed rather than static proof.
 - **Ready but not live yet**: the publish-ready MCP package
-  `@uiq/mcp-server`, the planned `prooflane-mcp` CLI shape, the generic
-  in-repo skill scaffold, and other external distribution listings that are
+  `@uiq/mcp-server`, the planned `prooflane-mcp` CLI shape, the companion
+  in-repo skill packet, and other external distribution listings that are
   prepared but not published.
 - **Not published yet**: npm, PyPI, public Skills marketplace listings, public
   Docker images, and hosted SaaS claims.
 - Distribution-ready summaries live in [DISTRIBUTION.md](../DISTRIBUTION.md)
   and [INTEGRATIONS.md](../INTEGRATIONS.md).
+
+Quick map:
+
+- **front door first:** `README.md` + `docs/get-started.md`
+- **proof second:** `docs/proof-center.md`
+- **MCP / skill later:** `services/mcp-server/` docs + `docs/skills/prooflane-mcp/`
+- **remote GitHub truth:** re-check through
+  `docs/reference/public-readiness.md` before treating homepage/release/discussion
+  state as fresh fact
 
 Use these two short pages when you want the truth without reading the full
 architecture stack:
@@ -84,7 +95,7 @@ architecture stack:
 - [docs/reference/resolution-overrides.md](./reference/resolution-overrides.md):
   dependency override registry
 
-## Runtime And Extension
+## Runtime And Integration Surfaces
 
 - [docs/architecture.md](./architecture.md): canonical architecture contract
 - [docs/reference/integration-entrypoints.md](./reference/integration-entrypoints.md): builder map for HTTP, MCP, frontend hooks, and generated client surfaces
@@ -106,6 +117,10 @@ architecture stack:
 
 ## MCP
 
+These docs describe the **companion integration lane**.
+They are real and usable today, but they are not the primary Prooflane product
+story.
+
 - [docs/reference/integration-entrypoints.md](./reference/integration-entrypoints.md):
   builder entry map before you choose HTTP vs MCP vs repo-internal client code
 - [docs/how-to/mcp-agent-review-loop.md](./how-to/mcp-agent-review-loop.md):
@@ -117,7 +132,7 @@ architecture stack:
   client setup
 - [docs/mcp.md](./mcp.md): full MCP contract
 - [docs/skills/prooflane-mcp/SKILL.md](./skills/prooflane-mcp/SKILL.md):
-  generic in-repo skill scaffold for `@uiq/mcp-server` / `prooflane-mcp`
+  generic in-repo companion skill scaffold for `@uiq/mcp-server` / `prooflane-mcp`
 
 Suggested roles:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,11 +15,14 @@ that has not happened yet.
 - **Remote GitHub routes exist**: repository, homepage, Discussions, and
   release surfaces remain audit-backed rather than static proof.
 - **Ready but not live yet**: the publish-ready MCP package
-  `@uiq/mcp-server`, the planned `prooflane-mcp` CLI shape, the companion
-  in-repo skill packet, and other external distribution listings that are
-  prepared but not published.
-- **Not published yet**: npm, PyPI, public Skills marketplace listings, public
-  Docker images, and hosted SaaS claims.
+  `@uiq/mcp-server`, the planned `prooflane-mcp` CLI shape, and other external
+  distribution listings that are prepared but not published.
+- **Companion skill host state**: `docs/skills/prooflane-mcp/` is listed live
+  on ClawHub and still review-pending on OpenHands/extensions; that host state
+  belongs to the companion skill lane only.
+- **Not published yet**: npm, PyPI, additional public Skills marketplace
+  listings beyond the ClawHub companion packet, public Docker images, and
+  hosted SaaS claims.
 - Distribution-ready summaries live in [DISTRIBUTION.md](../DISTRIBUTION.md)
   and [INTEGRATIONS.md](../INTEGRATIONS.md).
 

--- a/docs/skills/prooflane-mcp/README.md
+++ b/docs/skills/prooflane-mcp/README.md
@@ -1,0 +1,63 @@
+# Prooflane MCP Public Skill
+
+This folder is the public, self-contained skill packet for Prooflane's
+repo-native MCP surface.
+
+In plain language:
+
+> this is the companion packet on the side desk.
+> the main product still lives at the stress-lab front door.
+
+## Purpose
+
+Use it when you want one portable skill folder that teaches:
+
+- what Prooflane helps an agent do today
+- how to attach the repo-native stdio MCP server
+- which tool families are safe first
+- what a concrete first-success path looks like
+- which package, marketplace, and hosted claims remain out of bounds
+
+## What this packet includes
+
+- `SKILL.md`
+- `manifest.yaml`
+- `references/README.md`
+- `references/INSTALL.md`
+- `references/OPENHANDS_MCP_CONFIG.json`
+- `references/OPENCLAW_MCP_CONFIG.json`
+- `references/CAPABILITIES.md`
+- `references/DEMO.md`
+- `references/TROUBLESHOOTING.md`
+
+## Best-fit hosts
+
+- OpenHands/extensions contribution flow
+- ClawHub-style skill publication
+- standalone skill imports that expect one folder with install, config,
+  capability, and demo notes
+
+## Packet role
+
+- **Primary product stays elsewhere:** `README.md` and `docs/get-started.md`
+  remain the main Prooflane front door.
+- **This folder is a companion packet:** it teaches repo-native MCP attach and
+  proof-safe first steps for host-native skill flows.
+- **This folder is not the storefront:** any packet-lane review or listing
+  state here does not prove package publication, browser-extension listing, or
+  hosted Prooflane availability.
+
+## Current packet-lane state
+
+- OpenHands/extensions is currently `review-pending` via PR `#161`
+- ClawHub is still `ready-but-not-listed` in the repo-owned packet ledger
+- those packet-lane states apply only to this skill folder, not to the main
+  Prooflane product lane
+
+## What this packet must not claim
+
+- no live OpenHands listing without fresh PR/read-back
+- no live ClawHub listing without fresh host-side read-back
+- no published npm package or public Docker image unless the repo has fresh
+  proof
+- no hosted Prooflane SaaS claim

--- a/docs/skills/prooflane-mcp/README.md
+++ b/docs/skills/prooflane-mcp/README.md
@@ -50,14 +50,17 @@ Use it when you want one portable skill folder that teaches:
 ## Current packet-lane state
 
 - OpenHands/extensions is currently `review-pending` via PR `#161`
-- ClawHub is still `ready-but-not-listed` in the repo-owned packet ledger
+- ClawHub is now `listed-live` at
+  `https://clawhub.ai/xiaojiou176/prooflane-mcp` after fresh host-side
+  read-back on `2026-04-09`
 - those packet-lane states apply only to this skill folder, not to the main
   Prooflane product lane
 
 ## What this packet must not claim
 
 - no live OpenHands listing without fresh PR/read-back
-- no live ClawHub listing without fresh host-side read-back
+- no broader package, marketplace, or product claim beyond the fresh ClawHub
+  host-side read-back for this companion packet
 - no published npm package or public Docker image unless the repo has fresh
   proof
 - no hosted Prooflane SaaS claim

--- a/docs/skills/prooflane-mcp/SKILL.md
+++ b/docs/skills/prooflane-mcp/SKILL.md
@@ -22,8 +22,9 @@ package-registry or hosted distribution that does not exist yet.
 - Local stdio startup does **not** use OAuth; protected HTTP/API and
   automation surfaces keep the existing token/header contract.
 - Prooflane is **not** currently a hosted SaaS service.
-- This skill is a generic in-repo scaffold. It is **not** a published skill
-  marketplace artifact yet.
+- This skill remains a generic in-repo scaffold and is now published on
+  ClawHub as a companion packet, but that does **not** imply npm publication,
+  hosted Prooflane distribution, or main-product marketplace listing.
 
 ## Prerequisites
 

--- a/docs/skills/prooflane-mcp/SKILL.md
+++ b/docs/skills/prooflane-mcp/SKILL.md
@@ -31,7 +31,7 @@ package-registry or hosted distribution that does not exist yet.
 - Node.js 20+
 - pnpm
 - Python 3.12+
-- A local shell session in the repository root
+- A local shell session inside the cloned `ui-automation-control-plane` checkout
 
 ## Canonical Repo
 
@@ -68,7 +68,7 @@ What success looks like:
 
 ## Repo-Native MCP Start (Today)
 
-Start the current MCP server from the repository:
+Start the current repo-native MCP server from your cloned checkout:
 
 ```bash
 pnpm mcp:start
@@ -102,7 +102,7 @@ Do **not** claim this package is published until registry publication really hap
     "uiq": {
       "command": "pnpm",
       "args": ["mcp:start"],
-      "cwd": "/ABSOLUTE/PATH/TO/REPO",
+      "cwd": "/absolute/path/to/ui-automation-control-plane",
       "env": {
         "UIQ_MCP_API_BASE_URL": "http://127.0.0.1:18080",
         "UIQ_MCP_TOOL_GROUPS": "advanced,analysis,proof"
@@ -142,7 +142,7 @@ Do **not** claim this package is published until registry publication really hap
 
 ## Minimal Verification
 
-Run these from the repo root:
+Run these from your cloned `ui-automation-control-plane` checkout:
 
 ```bash
 pnpm mcp:check
@@ -160,13 +160,13 @@ Expected result:
 - docs contract passes
 - MCP smoke passes
 
-## Troubleshooting
+## Start here
 
-- If MCP starts but cannot reach the local app stack:
-  set `UIQ_MCP_API_BASE_URL=http://127.0.0.1:17380`
-- If governed runs fail:
-  verify whether `AUTOMATION_API_TOKEN` or `GEMINI_API_KEY` is required for the path you chose
-- If you only need the UI first-look:
-  use `./scripts/dev-up.sh` first; do not start with deeper proof lanes
-- If a claim sounds like package registry, marketplace, or hosted SaaS distribution:
-  stop and verify it in `DISTRIBUTION.md` before repeating it
+1. Read [references/INSTALL.md](references/INSTALL.md)
+2. Load the right host config from:
+   - [references/OPENHANDS_MCP_CONFIG.json](references/OPENHANDS_MCP_CONFIG.json)
+   - [references/OPENCLAW_MCP_CONFIG.json](references/OPENCLAW_MCP_CONFIG.json)
+3. Skim the tool surface in [references/CAPABILITIES.md](references/CAPABILITIES.md)
+4. Run the first review loop from [references/DEMO.md](references/DEMO.md)
+5. If attach or proof fails, use
+   [references/TROUBLESHOOTING.md](references/TROUBLESHOOTING.md)

--- a/docs/skills/prooflane-mcp/manifest.yaml
+++ b/docs/skills/prooflane-mcp/manifest.yaml
@@ -8,8 +8,9 @@ entrypoint: SKILL.md
 package_shape: skill-folder
 registry_targets:
   clawhub:
-    status: ready-but-not-listed
+    status: listed-live
     package_shape: skill-folder
+    listing_url: https://clawhub.ai/xiaojiou176/prooflane-mcp
     submit_via: clawhub publish . --slug prooflane-mcp --name "Prooflane MCP Skill" --version 0.1.0 --tags mcp,proof,automation,review,prooflane
   openhands-extensions:
     status: review-pending

--- a/docs/skills/prooflane-mcp/manifest.yaml
+++ b/docs/skills/prooflane-mcp/manifest.yaml
@@ -4,6 +4,26 @@ summary: >
   Generic skill scaffold for teaching an agent to clone, install, configure,
   verify, and use the Prooflane repo-native MCP server and local product paths.
 protocol: stdio
+entrypoint: SKILL.md
+package_shape: skill-folder
+registry_targets:
+  clawhub:
+    status: ready-but-not-listed
+    package_shape: skill-folder
+    submit_via: clawhub publish . --slug prooflane-mcp --name "Prooflane MCP Skill" --version 0.1.0 --tags mcp,proof,automation,review,prooflane
+  openhands-extensions:
+    status: review-pending
+    package_shape: skill-folder
+    submission_url: https://github.com/OpenHands/extensions/pull/161
+    submit_via: submit this folder as skills/prooflane-mcp/ in OpenHands/extensions
+boundaries:
+  packet_role: companion-skill-packet
+  primary_product_lane: ai-native WebUI stress lab front door
+  listing_scope_note: OpenHands or ClawHub status applies to this skill packet only and does not prove Prooflane browser/store publication, package publication, or hosted SaaS distribution.
+  not_claimed:
+    - No browser-extension product or browser-store listing is claimed here
+    - No published npm or PyPI package is claimed here
+    - No hosted Prooflane SaaS state is claimed here
 installation:
   repo: https://github.com/xiaojiou176-open/ui-automation-control-plane
   steps:
@@ -15,7 +35,7 @@ configuration:
     command: pnpm
     args:
       - mcp:start
-    cwd: /ABSOLUTE/PATH/TO/REPO
+    cwd: /absolute/path/to/ui-automation-control-plane
     env:
       UIQ_MCP_API_BASE_URL: http://127.0.0.1:18080
       UIQ_MCP_TOOL_GROUPS: advanced,analysis,proof
@@ -45,3 +65,13 @@ capabilities:
   - repo-native stdio MCP startup
   - governed run and proof path orientation
   - truthful distribution boundary guidance
+pair_with:
+  - SKILL.md
+  - README.md
+  - references/README.md
+  - references/INSTALL.md
+  - references/CAPABILITIES.md
+  - references/DEMO.md
+  - references/OPENHANDS_MCP_CONFIG.json
+  - references/OPENCLAW_MCP_CONFIG.json
+  - references/TROUBLESHOOTING.md

--- a/docs/skills/prooflane-mcp/references/CAPABILITIES.md
+++ b/docs/skills/prooflane-mcp/references/CAPABILITIES.md
@@ -1,0 +1,36 @@
+# Prooflane MCP Capabilities
+
+These are the current Prooflane tool families surfaced by the repo-native MCP
+server.
+
+## Best first tools
+
+1. `uiq_catalog`
+   - read the top-level surface and workflow catalog
+2. `uiq_run`
+   - inspect the current run lane when the user already has a run target
+3. `uiq_run_and_report`
+   - combine run execution context with a report-style summary
+4. `uiq_proof`
+   - inspect proof bundles and governed evidence surfaces
+
+## Good supporting reads
+
+- `uiq_api_workflow`
+- `uiq_api_automation`
+- `uiq_quality_read`
+- `uiq_read_artifact`
+- `uiq_list_runs`
+- `uiq_read_repo_doc`
+
+## Advanced follow-through tools
+
+- `uiq_read_run_ai_review`
+- `uiq_generate_release_brief`
+- `uiq_find_similar_failures`
+- `uiq_explain_template_feasibility`
+- `uiq_list_manual_gates`
+- `uiq_compare_perf`
+- `uiq_model_target_capabilities`
+
+Treat advanced tools as second-pass or reviewer-only surfaces.

--- a/docs/skills/prooflane-mcp/references/DEMO.md
+++ b/docs/skills/prooflane-mcp/references/DEMO.md
@@ -1,0 +1,30 @@
+# First-Success Path
+
+## Demo prompt
+
+Use Prooflane as a repo-native MCP surface. Start with `uiq_catalog` to confirm
+the server is attached. Then inspect one run or run summary with `uiq_run` or
+`uiq_run_and_report`. If proof artifacts are already present, follow with
+`uiq_proof` or `uiq_read_artifact`. Summarize the current lane, the most
+important proof artifact, and the next action without claiming a published
+marketplace listing.
+
+## Expected tool sequence
+
+1. `uiq_catalog`
+2. `uiq_run`
+3. `uiq_run_and_report`
+4. `uiq_proof` or `uiq_read_artifact`
+
+## Visible success criteria
+
+- the host attaches the repo-native MCP server
+- the agent cites one real run or artifact instead of a generic stress-lab
+  story
+- the answer stays grounded in current repo-native Prooflane surfaces
+
+## What to check if it fails
+
+1. `pnpm mcp:check` still passes
+2. `UIQ_MCP_API_BASE_URL` points at a reachable backend if live reads are needed
+3. the host config still points at the real repo checkout

--- a/docs/skills/prooflane-mcp/references/INSTALL.md
+++ b/docs/skills/prooflane-mcp/references/INSTALL.md
@@ -1,0 +1,38 @@
+# Install And Attach Prooflane MCP
+
+## Local repo setup
+
+```bash
+git clone https://github.com/xiaojiou176-open/ui-automation-control-plane.git
+cd ui-automation-control-plane
+./scripts/setup.sh
+```
+
+If you already trust the workspace toolchain, `pnpm install` is enough for JS
+dependencies.
+
+Before loading the host config snippets in this folder, replace
+`/absolute/path/to/ui-automation-control-plane` with the real path to your
+local clone.
+
+## Start the current repo-native MCP server
+
+```bash
+pnpm mcp:start
+```
+
+## Verification commands
+
+```bash
+pnpm mcp:check
+pnpm mcp:build
+pnpm mcp:package:smoke
+pnpm mcp:doc:contract
+pnpm mcp:smoke
+```
+
+## Truth boundary
+
+This packet teaches the repo-native stdio MCP surface that works today.
+The package shape `@uiq/mcp-server` / `prooflane-mcp` is publish-ready but not
+yet published.

--- a/docs/skills/prooflane-mcp/references/OPENCLAW_MCP_CONFIG.json
+++ b/docs/skills/prooflane-mcp/references/OPENCLAW_MCP_CONFIG.json
@@ -1,0 +1,17 @@
+{
+  "mcp": {
+    "servers": {
+      "uiq": {
+        "command": "pnpm",
+        "args": [
+          "mcp:start"
+        ],
+        "cwd": "/ABSOLUTE/PATH/TO/REPO",
+        "env": {
+          "UIQ_MCP_API_BASE_URL": "http://127.0.0.1:18080",
+          "UIQ_MCP_TOOL_GROUPS": "advanced,analysis,proof"
+        }
+      }
+    }
+  }
+}

--- a/docs/skills/prooflane-mcp/references/OPENHANDS_MCP_CONFIG.json
+++ b/docs/skills/prooflane-mcp/references/OPENHANDS_MCP_CONFIG.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "uiq": {
+      "command": "pnpm",
+      "args": [
+        "mcp:start"
+      ],
+      "cwd": "/ABSOLUTE/PATH/TO/REPO",
+      "env": {
+        "UIQ_MCP_API_BASE_URL": "http://127.0.0.1:18080",
+        "UIQ_MCP_TOOL_GROUPS": "advanced,analysis,proof"
+      }
+    }
+  }
+}

--- a/docs/skills/prooflane-mcp/references/README.md
+++ b/docs/skills/prooflane-mcp/references/README.md
@@ -1,0 +1,16 @@
+# Prooflane MCP References
+
+## File map
+
+- `INSTALL.md`
+  - clone, attach, and verification path
+- `OPENHANDS_MCP_CONFIG.json`
+  - OpenHands-style `mcpServers` snippet
+- `OPENCLAW_MCP_CONFIG.json`
+  - OpenClaw-style `mcp.servers` snippet
+- `CAPABILITIES.md`
+  - current Prooflane tool families and safe-first order
+- `DEMO.md`
+  - first-success prompt and expected tool sequence
+- `TROUBLESHOOTING.md`
+  - attach, backend, and proof failure checks

--- a/docs/skills/prooflane-mcp/references/TROUBLESHOOTING.md
+++ b/docs/skills/prooflane-mcp/references/TROUBLESHOOTING.md
@@ -1,0 +1,21 @@
+# Troubleshooting
+
+## The host cannot attach the MCP server
+
+- confirm the `cwd` points at the real cloned `ui-automation-control-plane`
+  checkout
+- rerun `pnpm install`
+- rerun `pnpm mcp:check` and `pnpm mcp:build`
+
+## The MCP server starts but the live stack is unreachable
+
+- set `UIQ_MCP_API_BASE_URL=http://127.0.0.1:17380`
+- confirm the backend health endpoint is reachable
+- if the task does not need live API reads, stay on repo-native docs and proof
+  surfaces instead
+
+## The agent jumps into advanced tools too early
+
+- restart from `uiq_catalog`
+- keep `uiq_run`, `uiq_run_and_report`, and `uiq_proof` as the first-success path
+- treat release-analysis and similarity tools as second-pass reviewer aids

--- a/scripts/ci/docker-env.sh
+++ b/scripts/ci/docker-env.sh
@@ -364,7 +364,7 @@ uiq_collect_forward_env_args() {
     uiq_append_env_arg_if_set "$target_array_name" "$env_name"
   done < <(uiq_collect_contract_env_names)
 
-  for env_name in CI GITHUB_ACTIONS GITHUB_REF GITHUB_SHA GITHUB_RUN_ID GITHUB_RUN_ATTEMPT; do
+  for env_name in CI GITHUB_ACTIONS GITHUB_REF GITHUB_SHA GITHUB_RUN_ID GITHUB_RUN_ATTEMPT GH_TOKEN GITHUB_TOKEN; do
     uiq_append_env_arg_if_set "$target_array_name" "$env_name"
   done
 

--- a/scripts/lint-all.sh
+++ b/scripts/lint-all.sh
@@ -22,6 +22,17 @@ should_cleanup_node_artifacts_on_exit() {
   esac
 }
 
+read_bool() {
+  local raw="${1:-}"
+  local fallback="${2:-0}"
+  case "$raw" in
+    1|true|TRUE|yes|YES|on|ON) echo "1" ;;
+    0|false|FALSE|no|NO|off|OFF) echo "0" ;;
+    "") echo "$fallback" ;;
+    *) echo "$fallback" ;;
+  esac
+}
+
 shared_node_bin_ready() {
   local bin_name="$1"
   bash scripts/lib/node-bin.sh "$bin_name" --version >/dev/null 2>&1
@@ -185,7 +196,11 @@ add_check "root-typecheck" "bash scripts/lib/pnpm-safe.sh typecheck"
 add_check "command-center-eslint" "$COMMAND_CENTER_ESLINT_CMD"
 add_check "automation-eslint" "$AUTOMATION_ESLINT_CMD"
 add_check "service-api-ruff" "$SERVICE_API_RUFF_CMD"
-add_check "sensitive-surface-gate" "node scripts/ci/check-sensitive-surface-leaks.mjs"
+if [[ "$(read_bool "${UIQ_SKIP_SENSITIVE_SURFACE_GATE:-}" 0)" != "1" ]]; then
+  add_check "sensitive-surface-gate" "node scripts/ci/check-sensitive-surface-leaks.mjs"
+else
+  echo "[lint-all] skip sensitive-surface-gate (covered by upstream canonical gate)"
+fi
 add_check "host-safety-gate" "bash scripts/ci/host-safety-gate.sh"
 
 echo "[lint-all] running ${#CHECK_NAMES[@]} checks in parallel"

--- a/scripts/mcp/sync-doc-contract.ts
+++ b/scripts/mcp/sync-doc-contract.ts
@@ -326,8 +326,14 @@ function main(): void {
   if (!packageJson.scripts?.prepack) {
     packageMetadataIssues.push("package.json must define prepack");
   }
-  if (!/npm pack --dry-run/.test(packageJson.scripts?.["package:smoke"] ?? "")) {
-    packageMetadataIssues.push("package:smoke must verify npm pack --dry-run");
+  if (
+    !/pnpm-safe\.sh pack --pack-destination \.runtime-cache\/package-smoke/.test(
+      packageJson.scripts?.["package:smoke"] ?? "",
+    )
+  ) {
+    packageMetadataIssues.push(
+      "package:smoke must verify the publish-ready pack path through scripts/lib/pnpm-safe.sh",
+    );
   }
   if (packageMetadataIssues.length > 0) {
     drifts.push({ docPath: packageJsonPath, issues: packageMetadataIssues });

--- a/scripts/repo/doctor-repo.sh
+++ b/scripts/repo/doctor-repo.sh
@@ -4,16 +4,28 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 
+read_bool() {
+  local raw="${1:-}"
+  case "$raw" in
+    1|true|TRUE|yes|YES|on|ON) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 # Most doctor gates only need the already-prepared shared node topology.
 # Re-running shared-link repair before every node-governance entry makes the
 # PR gate dramatically slower without changing the assertions those gates make.
 export UIQ_SKIP_SHARED_MODULE_LINK_REPAIR=1
 
-bash scripts/lib/pnpm-safe.sh gate:root:allowlist
-bash scripts/lib/pnpm-safe.sh gate:cache:governance
-bash scripts/lib/pnpm-safe.sh gate:cache:contract
-bash scripts/lib/pnpm-safe.sh gate:config:convergence
-bash scripts/lib/pnpm-safe.sh gate:dependency:boundaries
+if ! read_bool "${UIQ_DOCTOR_REPO_SKIP_REDUNDANT_GOVERNANCE:-0}"; then
+  bash scripts/lib/pnpm-safe.sh gate:root:allowlist
+  bash scripts/lib/pnpm-safe.sh gate:cache:governance
+  bash scripts/lib/pnpm-safe.sh gate:cache:contract
+  bash scripts/lib/pnpm-safe.sh gate:config:convergence
+  bash scripts/lib/pnpm-safe.sh gate:dependency:boundaries
+else
+  echo "[doctor:repo] skip redundant governance gates (already enforced by gate:repo:fast)"
+fi
 bash scripts/lib/pnpm-safe.sh gate:english:deep-water
 bash scripts/lib/pnpm-safe.sh gate:external:source-purity
 bash scripts/lib/pnpm-safe.sh gate:upstream:private-coupling

--- a/scripts/test-matrix.sh
+++ b/scripts/test-matrix.sh
@@ -149,6 +149,7 @@ RUN_BACKEND="$(read_bool "${UIQ_SUITE_BACKEND:-}" 1)"
 RUN_TEST_TRUTH_GATE="$(read_bool "${UIQ_SUITE_TEST_TRUTH_GATE:-}" 1)"
 RUN_AUTOMATION_CHECK="$(read_bool "${UIQ_SUITE_AUTOMATION_CHECK:-}" 1)"
 RUN_ORCHESTRATOR_MCP="$(read_bool "${UIQ_SUITE_ORCHESTRATOR_MCP:-}" 1)"
+RUN_ORCHESTRATOR_MCP_CONTRACT="$(read_bool "${UIQ_SUITE_ORCHESTRATOR_MCP_CONTRACT:-}" 1)"
 DEFAULT_COVERAGE_GATE="1"
 RUN_COVERAGE_GATE="$(read_bool "${UIQ_SUITE_COVERAGE_GATE:-${UIQ_VERIFY_ENABLE_COVERAGE_GATE:-$DEFAULT_COVERAGE_GATE}}" "$DEFAULT_COVERAGE_GATE")"
 CI_CONTEXT="$(read_bool "${CI:-}" 0)"
@@ -529,7 +530,9 @@ fi
 
 if [[ "$RUN_ORCHESTRATOR_MCP" == "1" ]]; then
   orchestrator_default_cmd="bash scripts/lib/node-bin.sh tsx --test packages/orchestrator/src/commands/run.test.ts packages/orchestrator/src/commands/run.runid.test.ts"
-  orchestrator_default_cmd="$(append_cmd_segment "$orchestrator_default_cmd" "${PNPM_SAFE} mcp:check")"
+  if [[ "$RUN_ORCHESTRATOR_MCP_CONTRACT" == "1" ]]; then
+    orchestrator_default_cmd="$(append_cmd_segment "$orchestrator_default_cmd" "${PNPM_SAFE} mcp:check")"
+  fi
   resolve_suite_cmd \
     "orchestrator-mcp-gate" \
     "$orchestrator_default_cmd" \

--- a/services/mcp-server/README.md
+++ b/services/mcp-server/README.md
@@ -4,6 +4,12 @@
 evidence through the MCP protocol. It is an adapter boundary, not the product
 frontend or the main backend business surface.
 
+In plain language:
+
+> this package is the companion translator booth for MCP-capable clients.
+> it is not the main Prooflane exhibit and it is not a browser-extension
+> product.
+
 This package is the **publish-ready MCP artifact target** for Prooflane.
 Today it still ships from the repository. It is **not** yet published to npm or
 another registry.

--- a/services/mcp-server/package.json
+++ b/services/mcp-server/package.json
@@ -48,7 +48,7 @@
     "prepack": "bash ../../scripts/lib/node-bin.sh tsc -p tsconfig.build.json",
     "check": "bash ../../scripts/lib/node-bin.sh tsc -p tsconfig.json --noEmit",
     "test": "bash ../../scripts/lib/node-bin.sh tsx --test tests/mcp-*.test.ts",
-    "package:smoke": "npm pack --dry-run >/dev/null && node scripts/smoke-built-bin.mjs"
+    "package:smoke": "bash ../../scripts/lib/pnpm-safe.sh pack --pack-destination .runtime-cache/package-smoke >/dev/null && node scripts/smoke-built-bin.mjs"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.26.0",

--- a/services/mcp-server/scripts/smoke-built-bin.mjs
+++ b/services/mcp-server/scripts/smoke-built-bin.mjs
@@ -77,5 +77,9 @@ try {
     child.kill("SIGTERM");
   }
   await waitForExit(child);
+  await rm(resolve(packageRoot, ".runtime-cache/package-smoke"), {
+    recursive: true,
+    force: true,
+  });
   await rm(resolve(packageRoot, "dist"), { recursive: true, force: true });
 }

--- a/services/mcp-server/src/tools/register-tools/register-run-tools.ts
+++ b/services/mcp-server/src/tools/register-tools/register-run-tools.ts
@@ -32,6 +32,7 @@ import {
   analyzeSecurity,
   analyzeVisual,
   appendRunOverrides,
+  comparePerf,
   desktopInputWarnings,
   latestRunId,
   listRunIds,
@@ -882,10 +883,25 @@ export function registerRunTools(
             metrics_delta?: { values?: Record<string, unknown> };
             compare?: { metrics_delta?: { values?: Record<string, unknown> } };
           };
-          const deltas =
+          const rawDeltas =
             payload.metrics_delta?.values ??
             payload.compare?.metrics_delta?.values ??
             {};
+          const normalizedRemoteDeltas = Object.fromEntries(
+            Object.entries(rawDeltas).map(([key, value]) => {
+              if (typeof value === "number") {
+                return [key, { delta: value }];
+              }
+              return [key, value];
+            }),
+          );
+          const localComparison = comparePerf(runIdA, runIdB) as {
+            deltas?: Record<string, unknown>;
+          };
+          const deltas = {
+            ...normalizedRemoteDeltas,
+            ...(localComparison.deltas ?? {}),
+          };
           return {
             content: [
               {

--- a/services/mcp-server/tests/mcp-doc-tool-contract.test.ts
+++ b/services/mcp-server/tests/mcp-doc-tool-contract.test.ts
@@ -380,7 +380,7 @@ test("publish-ready package truth stays aligned across docs, skill scaffold, and
   assert.ok(packageJson.scripts?.prepack, "package.json must define a prepack build hook");
   assert.match(
     packageJson.scripts?.["package:smoke"] ?? "",
-    /npm pack --dry-run/,
+    /pnpm-safe\.sh pack --pack-destination \.runtime-cache\/package-smoke/,
     "package:smoke must verify the pack path",
   );
 


### PR DESCRIPTION
## Summary
- replay the exact Prooflane submit-ready diff from `#20` onto a fresh signed branch based on current `main`
- preserve the same three logical changes while replacing the unsigned commits blocked by `required_signatures`
- keep `#18` retired; this PR only supersedes `#20` as the legal merge path

## Why a new PR exists
- `#20` is no longer a CI-red line: checks are green, but merge is blocked by `required_signatures` on unsigned commits `34f0a37e179515361cd6ae014af029454e5a09b0` and `6f8c20b23d4443ef3089997b2439d5d37186da63`
- this replay branch carries the same content on new GitHub-verified commits:
  - `113932ee99ad50613845fcbef23189c7e667c861`
  - `265c672e8511eabbd0f6aeddcf0e40b1e80c2ab0`
  - `28ea03597655652b72eec3d1e599269118e5fde8`

## Supersedes
- blocked predecessor: #20
- retired history: #18

## Verification
- `gh api repos/xiaojiou176-open/ui-automation-control-plane/commits/<sha>` for all three replay commits -> `verified=true`, `reason=valid`
- predecessor `#20` still shows `reviewDecision=APPROVED`, `mergeStateStatus=BLOCKED`, with required checks green
