### PR TITLE
feat(ui): land launch-first command center hierarchy

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,6 +16,7 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   UIQ_ALLOW_HOST_GATE_DIAGNOSTIC: "1"
   UIQ_ALLOW_HOST_GATE_DIAGNOSTIC_REASON: pr-quick-gate
+  UIQ_BOOTSTRAP_COREPACK_VERSION: "0.34.6"
 
 jobs:
   pr-quick-gate:
@@ -35,6 +36,10 @@ jobs:
       - name: Activate pnpm from root packageManager
         run: |
           set -euo pipefail
+          export npm_config_prefix="${RUNNER_TEMP}/uiq-corepack-bootstrap"
+          echo "${npm_config_prefix}/bin" >> "$GITHUB_PATH"
+          export PATH="${npm_config_prefix}/bin:$PATH"
+          npm install -g "corepack@${UIQ_BOOTSTRAP_COREPACK_VERSION}"
           corepack enable
           corepack prepare "$(node -p "require('./package.json').packageManager")" --activate
       - name: OpenAI residue hard gate

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Choose the shortest honest path before you read the heavier engineering stack:
    [MCP quickstart](./docs/how-to/mcp-quickstart-1pager.md) and
    [INTEGRATIONS.md](./INTEGRATIONS.md).
 
-![Prooflane Command Center running locally with Stress Lab, Runs and Blocks, Flow Studio, and Advanced Review available in the operator shell. This is a maintainer-local product view, not a hosted public demo or proof of live GitHub settings.](./docs/assets/prooflane-command-center-real.png)
+![Prooflane studio preview showing the launch-first operator path: Stress Lab first, then Runs and Blocks, then Flow Studio, with Advanced Review as the deeper governed layer behind the first visible result.](./docs/assets/prooflane-studio-preview.svg)
 ![Prooflane result path diagram showing the local first-look path, the governed run path, and the MCP connection route.](./docs/assets/prooflane-result-path.svg)
 
 ## Distribution Truth Today
@@ -109,14 +109,18 @@ What you should see:
 - API health on `http://127.0.0.1:17380/health/`
 - A live Stress Lab surface with URL-first parameters, lab-mode guidance, Runs & Blocks, and Advanced Review instead of a static docs-only experience
 
-The screenshot above is a real local run of the current English product
-surface. It is a maintainer-local product view, not a hosted public demo or a
-claim about live GitHub settings. A governed run is a separate step and
-requires a valid `GEMINI_API_KEY`.
-Current GitHub-side metadata and remote enforcement remain audit-backed states.
-Use [docs/reference/public-readiness.md](./docs/reference/public-readiness.md)
-and the latest audit artifacts for current remote truth instead of treating
-the historical closure snapshot as live GitHub proof.
+The preview card above is the current **public-facing shell map** for the
+launch-first IA. It is intentionally a semantic front-door visual, not a
+literal runtime screenshot, so README does not freeze an outdated local shell
+capture as if it were current product truth.
+
+If you want the live maintainer-local shell, run `./scripts/dev-up.sh` and use
+the app itself as the source of truth. A governed run is a separate step and
+requires a valid `GEMINI_API_KEY`. Current GitHub-side metadata and remote
+enforcement remain audit-backed states. Use
+[docs/reference/public-readiness.md](./docs/reference/public-readiness.md) and
+the latest audit artifacts for current remote truth instead of treating a
+historical closure snapshot as live GitHub proof.
 
 ## What Prooflane Gives You Right Now
 

--- a/apps/command-center/src/App.locale-shell.test.tsx
+++ b/apps/command-center/src/App.locale-shell.test.tsx
@@ -156,7 +156,22 @@ vi.mock("./views/QuickLaunchView", () => ({
 }));
 
 vi.mock("./components/ConsoleHeader", () => ({
-  default: ({ locale }: { locale: string }) => <div>{`console-header:${locale}`}</div>,
+  default: ({
+    locale,
+    activeView,
+    onRestartTour,
+  }: {
+    locale: string;
+    activeView: string;
+    onRestartTour: () => void;
+  }) => (
+    <div>
+      {`console-header:${locale}:${activeView}`}
+      <button type="button" onClick={onRestartTour}>
+        restart-tour
+      </button>
+    </div>
+  ),
 }));
 
 vi.mock("./components/ToastStack", () => ({
@@ -215,5 +230,26 @@ describe("App locale shell integration", () => {
     expect(text).toContain("confirm-dialog:zh-CN:确认:取消");
     expect(document.documentElement.lang).toBe("zh-CN");
     expect(document.documentElement.getAttribute("data-uiq-locale")).toBe("zh-CN");
+  });
+
+  it("routes restart onboarding back through launch before reopening the tour", () => {
+    hoisted.store.activeView = "tasks";
+    root = createRoot(container);
+
+    act(() => {
+      root.render(<App />);
+    });
+
+    const restartButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "restart-tour",
+    );
+    expect(restartButton).toBeTruthy();
+
+    act(() => {
+      restartButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(hoisted.store.setActiveView).toHaveBeenCalledWith("launch");
+    expect(hoisted.store.restartOnboarding).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/command-center/src/App.tsx
+++ b/apps/command-center/src/App.tsx
@@ -310,7 +310,6 @@ export default function App() {
   }, [createRun, isFirstUseActive, markFirstUseRunTriggered, store]);
 
   const handleGoToLaunch = useCallback(() => store.setActiveView("launch"), [store]);
-  const handleGoToTasks = useCallback(() => store.setActiveView("tasks"), [store]);
   const handleRestartOnboarding = useCallback(() => {
     store.setActiveView("launch");
     store.restartOnboarding();
@@ -443,7 +442,6 @@ export default function App() {
               firstUseProgress={firstUseProgress}
               canCompleteFirstUse={canCompleteFirstUse}
               onCompleteFirstUse={completeFirstUse}
-              onGoToTasks={handleGoToTasks}
             />
           )}
 

--- a/apps/command-center/src/App.tsx
+++ b/apps/command-center/src/App.tsx
@@ -310,6 +310,11 @@ export default function App() {
   }, [createRun, isFirstUseActive, markFirstUseRunTriggered, store]);
 
   const handleGoToLaunch = useCallback(() => store.setActiveView("launch"), [store]);
+  const handleGoToTasks = useCallback(() => store.setActiveView("tasks"), [store]);
+  const handleRestartOnboarding = useCallback(() => {
+    store.setActiveView("launch");
+    store.restartOnboarding();
+  }, [store]);
 
   useEffect(() => {
     if (!isFirstUseActive) {
@@ -378,7 +383,7 @@ export default function App() {
         onLocaleChange={store.setUiLocale as (locale: UiLocale) => void}
         onViewChange={store.setActiveView}
         onOpenHelp={() => store.setShowHelp(true)}
-        onRestartTour={store.restartOnboarding}
+        onRestartTour={handleRestartOnboarding}
       />
 
       {isRegisterRoute && (
@@ -438,6 +443,7 @@ export default function App() {
               firstUseProgress={firstUseProgress}
               canCompleteFirstUse={canCompleteFirstUse}
               onCompleteFirstUse={completeFirstUse}
+              onGoToTasks={handleGoToTasks}
             />
           )}
 
@@ -528,7 +534,7 @@ export default function App() {
           activeView={store.activeView}
           locale={store.uiLocale}
           onClose={() => store.setShowHelp(false)}
-          onRestartTour={store.restartOnboarding}
+          onRestartTour={handleRestartOnboarding}
         />
       )}
 

--- a/apps/command-center/src/components/ConsoleHeader.tsx
+++ b/apps/command-center/src/components/ConsoleHeader.tsx
@@ -14,6 +14,7 @@ import {
 } from "../constants/testIds";
 import type { AppView } from "../hooks/useAppStore";
 import { DEFAULT_UI_LOCALE, pickUiText, type UiLocale } from "../i18n/uiLocale";
+import { Badge, Button } from "./ui";
 
 interface ConsoleHeaderProps {
   runningCount: number;
@@ -40,6 +41,12 @@ const LANE_MAP_SUMMARY =
 
 const RECOMMENDED_FIRST_PATH =
   "Recommended first path: enter a URL, choose a lab mode, run the experiment, then inspect the latest result before opening Advanced Review.";
+
+const FIRST_USE_ROUTE_TITLE =
+  "New here? Use the shell like a runway: launch in Stress Lab first, then read Runs & Blocks before you branch into Flow Studio or Advanced Review.";
+
+const FIRST_USE_ROUTE_LATER_HINT =
+  "Flow Studio and Advanced Review still stay available, but they are later lanes after the first result exists.";
 
 const laneViews: LaneView[] = [
   {
@@ -173,6 +180,16 @@ function ConsoleHeader({
     locale,
     RECOMMENDED_FIRST_PATH,
     "\u63a8\u8350\u8def\u5f84\uff1a\u5148\u586b URL\uff0c\u9009\u5b9e\u9a8c\u6a21\u5f0f\uff0c\u542f\u52a8\u5b9e\u9a8c\uff0c\u518d\u8bfb\u7ed3\u679c\uff1b\u6700\u540e\u624d\u8fdb\u5165 Advanced Review\u3002",
+  );
+  const firstUseRouteTitle = pickUiText(
+    locale,
+    FIRST_USE_ROUTE_TITLE,
+    "\u7b2c\u4e00\u6b21\u6765\u8fd9\u91cc\uff0c\u5c31\u628a\u8fd9\u4e2a shell \u5f53\u6210\u4e00\u6761\u8dd1\u9053\uff1a\u5148\u5728 Stress Lab \u53d1\u8d77\u5b9e\u9a8c\uff0c\u518d\u53bb Runs & Blocks \u8bfb\u7ed3\u679c\uff0c\u4e4b\u540e\u624d\u5206\u53c9\u5230 Flow Studio \u6216 Advanced Review\u3002",
+  );
+  const firstUseRouteLaterHint = pickUiText(
+    locale,
+    FIRST_USE_ROUTE_LATER_HINT,
+    "Flow Studio \u548c Advanced Review \u8fd8\u5728\uff0c\u53ea\u662f\u5b83\u4eec\u5e94\u8be5\u51fa\u73b0\u5728\u4f60\u770b\u5230\u7b2c\u4e00\u4e2a\u7ed3\u679c\u4e4b\u540e\u3002",
   );
   const localizedLaneViews: LaneView[] = useMemo(
     () => [
@@ -340,6 +357,43 @@ function ConsoleHeader({
             <h1>Prooflane</h1>
             <p>{laneMapSummary}</p>
             <p>{recommendedFirstPath}</p>
+            <div className="card-raised mt-3" data-tour="launch-priority">
+              <p className="field-label">
+                {pickUiText(locale, "Start here", "\u4ece\u8fd9\u91cc\u5f00\u59cb")}
+              </p>
+              <p className="hint-text">{firstUseRouteTitle}</p>
+              <div className="form-actions">
+                <Button size="sm" onClick={() => onViewChange("launch")}>
+                  {pickUiText(locale, "1. Open Stress Lab", "1. \u6253\u5f00 Stress Lab")}
+                </Button>
+                <Button variant="secondary" size="sm" onClick={() => onViewChange("tasks")}>
+                  {pickUiText(locale, "2. Read Runs & Blocks", "2. \u67e5\u770b Runs & Blocks")}
+                </Button>
+              </div>
+              <div className="form-actions">
+                <Badge variant={activeView === "launch" ? "default" : "secondary"}>
+                  {pickUiText(locale, "First lane: Stress Lab", "\u7b2c\u4e00\u7ad9\uff1aStress Lab")}
+                </Badge>
+                <Badge variant={activeView === "tasks" ? "default" : "secondary"}>
+                  {pickUiText(
+                    locale,
+                    "Next lane: Runs & Blocks",
+                    "\u4e0b\u4e00\u7ad9\uff1aRuns & Blocks",
+                  )}
+                </Badge>
+                <Badge variant="secondary">
+                  {pickUiText(locale, "Later: Flow Studio", "\u7a0d\u540e\uff1aFlow Studio")}
+                </Badge>
+                <Badge variant="secondary">
+                  {pickUiText(
+                    locale,
+                    "Later: Advanced Review",
+                    "\u7a0d\u540e\uff1aAdvanced Review",
+                  )}
+                </Badge>
+              </div>
+              <p className="hint-text">{firstUseRouteLaterHint}</p>
+            </div>
           </div>
         </div>
         <div className="header-right">

--- a/apps/command-center/src/components/OnboardingTour.tsx
+++ b/apps/command-center/src/components/OnboardingTour.tsx
@@ -17,15 +17,17 @@ const LANE_MAP_SUMMARY =
 const RECOMMENDED_FIRST_PATH =
   "Recommended first path: enter a URL, choose a lab mode, run the experiment, then inspect the latest result before opening Advanced Review.";
 
-const TOUR_VIEW_GUIDES = {
-  launch:
-    "Stress Lab is where you begin. Confirm the target, choose a lab mode, and launch the first browser experiment.",
+const TOUR_PAGE_GUIDES = {
+  plan:
+    "This page is not a whole-product map. It exists to get one first result on screen: configure the target, choose a mode, run it, then read Runs & Blocks.",
+  parameters:
+    "Use the parameter panel to set the base URL, optional start URL, and success checkpoint before you try to launch anything.",
+  modes:
+    "Choose one lab mode that matches the first question you want answered. You do not need every lane on the first pass.",
+  actions:
+    "Launch from the command grid or a saved template only after the target is configured. Reusable shortcuts stay secondary to the first run.",
   tasks:
-    "Runs & Blocks is where you read the latest result, inspect failures, and clear manual blockers before running again.",
-  workshop:
-    "Flow Studio is where you deepen the experiment by editing journeys, replaying steps, and tightening what the run just taught you.",
-  review:
-    "Advanced Review is the optional governed layer for comparing proof bundles, AI summaries, and historical matches after the result already exists.",
+    "After launch, move to Runs & Blocks to read the verdict or clear a waiting gate such as OTP or manual input.",
 } as const;
 
 interface OnboardingTourProps {
@@ -53,65 +55,82 @@ function OnboardingTour({
     RECOMMENDED_FIRST_PATH,
     "\u63a8\u8350\u8def\u5f84\uff1a\u5148\u586b URL\uff0c\u9009\u5b9e\u9a8c\u6a21\u5f0f\uff0c\u542f\u52a8\u5b9e\u9a8c\uff0c\u518d\u8bfb\u7ed3\u679c\uff1b\u6700\u540e\u624d\u8fdb\u5165 Advanced Review\u3002",
   );
-  const localizedTourViewGuides = {
-    launch: pickUiText(
+  const localizedTourPageGuides = {
+    plan: pickUiText(
       locale,
-      TOUR_VIEW_GUIDES.launch,
-      "Stress Lab \u662f\u7b2c\u4e00\u7ad9\u3002\u5148\u786e\u8ba4\u76ee\u6807\uff0c\u518d\u9009\u62e9\u5b9e\u9a8c\u6a21\u5f0f\uff0c\u7136\u540e\u542f\u52a8\u7b2c\u4e00\u6b21\u6d4f\u89c8\u5668\u5b9e\u9a8c\u3002",
+      TOUR_PAGE_GUIDES.plan,
+      "这个页面不是整张产品地图，而是为了把第一个结果先跑出来：先配目标、再选模式、再运行，最后去 Runs & Blocks 读结论。",
+    ),
+    parameters: pickUiText(
+      locale,
+      TOUR_PAGE_GUIDES.parameters,
+      "先在参数面板里设置 base URL、可选 start URL 和 success checkpoint，然后再尝试发起实验。",
+    ),
+    modes: pickUiText(
+      locale,
+      TOUR_PAGE_GUIDES.modes,
+      "先选一个最符合当前问题的实验模式就够了，第一次不需要把所有 lane 都走一遍。",
+    ),
+    actions: pickUiText(
+      locale,
+      TOUR_PAGE_GUIDES.actions,
+      "只有在目标配置好之后，才从 command grid 或已保存模板发起运行。可复用快捷方式仍然应该排在首跑之后。",
     ),
     tasks: pickUiText(
       locale,
-      TOUR_VIEW_GUIDES.tasks,
-      "Runs & Blocks \u7528\u6765\u5148\u8bfb\u6700\u65b0\u7ed3\u679c\u3001\u770b\u5931\u8d25\u4e0e\u6682\u505c\u539f\u56e0\uff0c\u518d\u51b3\u5b9a\u662f\u5426\u7ee7\u7eed\u3002",
-    ),
-    workshop: pickUiText(
-      locale,
-      TOUR_VIEW_GUIDES.workshop,
-      "Flow Studio \u8d1f\u8d23\u66f4\u6df1\u4e00\u5c42\u7684\u6d41\u7a0b\u7f16\u8f91\u3001\u6b65\u9aa4\u91cd\u653e\u548c\u5b9e\u9a8c\u4f18\u5316\u3002",
-    ),
-    review: pickUiText(
-      locale,
-      TOUR_VIEW_GUIDES.review,
-      "Advanced Review \u662f\u53ef\u9009\u6cbb\u7406\u5c42\uff0c\u53ea\u6709\u5728\u7ed3\u679c\u5df2\u7ecf\u5b58\u5728\u4e14\u9700\u8981 proof\u3001AI \u6458\u8981\u6216\u5386\u53f2\u5bf9\u6bd4\u65f6\u624d\u6253\u5f00\u3002",
+      TOUR_PAGE_GUIDES.tasks,
+      "发起运行后，下一站就是 Runs & Blocks。在那里读结论，或者清掉 OTP / 手工输入这样的等待闸门。",
     ),
   } as const;
   const localizedSteps: TourStep[] = [
     {
-      selector: '[data-tour="welcome"]',
+      selector: '[data-tour="launch-plan"]',
       title: pickUiText(
         locale,
         "Step 1: Start from the target, not from the room list",
         "\u6b65\u9aa4 1\uff1a\u5148\u4ece\u76ee\u6807\u5f00\u59cb\uff0c\u800c\u4e0d\u662f\u5148\u770b\u623f\u95f4\u5217\u8868",
       ),
-      body: `${laneMapSummary} ${recommendedFirstPath}`,
+      body: `${localizedTourPageGuides.plan} ${laneMapSummary} ${recommendedFirstPath}`,
       position: "bottom",
     },
     {
-      selector: '[data-tour="tab-launch"]',
-      title: pickUiText(locale, "Step 2: Launch from Stress Lab", "\u6b65\u9aa4 2\uff1a\u4ece Stress Lab \u53d1\u8d77\u5b9e\u9a8c"),
-      body: localizedTourViewGuides.launch,
+      selector: '[data-tour="launch-parameters"]',
+      title: pickUiText(
+        locale,
+        "Step 2: Configure the target first",
+        "\u6b65\u9aa4 2\uff1a\u5148\u914d\u7f6e\u76ee\u6807",
+      ),
+      body: localizedTourPageGuides.parameters,
+      position: "bottom",
+    },
+    {
+      selector: '[data-tour="launch-modes"]',
+      title: pickUiText(
+        locale,
+        "Step 3: Choose one lab mode",
+        "\u6b65\u9aa4 3\uff1a\u9009\u4e00\u4e2a\u5b9e\u9a8c\u6a21\u5f0f",
+      ),
+      body: localizedTourPageGuides.modes,
+      position: "bottom",
+    },
+    {
+      selector: '[data-tour="launch-actions"]',
+      title: pickUiText(
+        locale,
+        "Step 4: Start the run from this page",
+        "\u6b65\u9aa4 4\uff1a\u5728\u8fd9\u4e2a\u9875\u9762\u53d1\u8d77\u8fd0\u884c",
+      ),
+      body: localizedTourPageGuides.actions,
       position: "bottom",
     },
     {
       selector: '[data-tour="tab-tasks"]',
-      title: pickUiText(locale, "Step 3: Read the result in Runs & Blocks", "\u6b65\u9aa4 3\uff1a\u5728 Runs & Blocks \u8bfb\u7ed3\u679c"),
-      body: localizedTourViewGuides.tasks,
-      position: "bottom",
-    },
-    {
-      selector: '[data-tour="tab-workshop"]',
-      title: pickUiText(locale, "Step 4: Deepen the journey in Flow Studio", "\u6b65\u9aa4 4\uff1a\u5728 Flow Studio \u6df1\u5316\u6d41\u7a0b"),
-      body: localizedTourViewGuides.workshop,
-      position: "bottom",
-    },
-    {
-      selector: '[data-tour="tab-review"]',
       title: pickUiText(
         locale,
-        "Step 5: Open Advanced Review only when needed",
-        "\u6b65\u9aa4 5\uff1a\u53ea\u6709\u9700\u8981\u65f6\u624d\u6253\u5f00 Advanced Review",
+        "Step 5: Move to Runs & Blocks next",
+        "\u6b65\u9aa4 5\uff1a\u4e0b\u4e00\u7ad9\u8f6c\u5230 Runs & Blocks",
       ),
-      body: localizedTourViewGuides.review,
+      body: localizedTourPageGuides.tasks,
       position: "bottom",
     },
   ];

--- a/apps/command-center/src/views/QuickLaunchView.tsx
+++ b/apps/command-center/src/views/QuickLaunchView.tsx
@@ -21,7 +21,14 @@ const LANE_MAP_SUMMARY =
 const RECOMMENDED_FIRST_PATH =
   "Recommended first path: enter a URL, choose a lab mode, run the experiment, then inspect the latest result before opening Advanced Review.";
 
-const LAB_MODES = [
+type LabMode = {
+  title: string;
+  description: string;
+  bestWhen: string;
+  badge: string;
+};
+
+const LAB_MODES: readonly LabMode[] = [
   {
     title: "Explore",
     description: "Crawl states, discover paths, and surface fragile interactions before you script or reuse them.",
@@ -60,15 +67,12 @@ const LAB_MODES = [
   },
 ] as const;
 
-function localizeLabMode(
-  locale: UiLocale,
-  mode: (typeof LAB_MODES)[number],
-): (typeof LAB_MODES)[number] {
+function localizeLabMode(locale: UiLocale, mode: LabMode): LabMode {
   if (locale === "en") {
     return mode;
   }
 
-  const translations: Record<(typeof LAB_MODES)[number]["title"], (typeof LAB_MODES)[number]> = {
+  const translations: Record<string, LabMode> = {
     Explore: {
       title: "探索",
       description: "遍历状态、发现路径，并在真正编写或复用流程之前先暴露脆弱交互。",
@@ -141,6 +145,7 @@ interface QuickLaunchViewProps {
   canCompleteFirstUse: boolean;
   onFirstUseStageChange: (stage: FirstUseStage) => void;
   onCompleteFirstUse: () => void;
+  onGoToTasks?: () => void;
 }
 
 function QuickLaunchView({
@@ -169,6 +174,7 @@ function QuickLaunchView({
   canCompleteFirstUse,
   onFirstUseStageChange,
   onCompleteFirstUse,
+  onGoToTasks = () => {},
 }: QuickLaunchViewProps) {
   const laneMapSummary = pickUiText(
     locale,
@@ -221,6 +227,89 @@ function QuickLaunchView({
   const canGoRun =
     (isCurrentStage("configure") || isCurrentStage("run")) && firstUseProgress.configValid;
   const canShowComplete = firstUseStage === "verify";
+  const firstUseStateTitle = !firstUseProgress.configValid
+    ? pickUiText(locale, "State: no config yet", "\u72b6\u6001\uff1a\u8fd8\u6ca1\u6709\u914d\u7f6e")
+    : !firstUseProgress.runTriggered
+      ? pickUiText(
+          locale,
+          "State: config ready, run not started",
+          "\u72b6\u6001\uff1a\u914d\u7f6e\u5df2\u5c31\u7eea\uff0c\u8fd8\u672a\u542f\u52a8",
+        )
+      : firstUseProgress.resultSeen
+        ? pickUiText(
+            locale,
+            "State: result is ready to read",
+            "\u72b6\u6001\uff1a\u7ed3\u679c\u5df2\u51c6\u5907\u597d",
+          )
+        : pickUiText(
+            locale,
+            "State: run is queued or still landing",
+            "\u72b6\u6001\uff1a\u8fd0\u884c\u5df2\u542f\u52a8\uff0c\u6b63\u5728\u843d\u5730",
+          );
+  const firstUseStateHint = !firstUseProgress.configValid
+    ? pickUiText(
+        locale,
+        "Fill in the target first. The parameter panel is the real step one for a first run.",
+        "\u5148\u628a\u76ee\u6807\u586b\u597d\u3002\u53c2\u6570\u9762\u677f\u624d\u662f\u7b2c\u4e00\u6b65\u7684\u771f\u6b63\u8d77\u70b9\u3002",
+      )
+    : !firstUseProgress.runTriggered
+      ? pickUiText(
+          locale,
+          "You are ready to choose one lab mode and launch a single experiment.",
+          "\u4f60\u73b0\u5728\u53ef\u4ee5\u9009\u4e00\u4e2a\u5b9e\u9a8c\u6a21\u5f0f\uff0c\u7136\u540e\u542f\u52a8\u7b2c\u4e00\u6b21\u5b9e\u9a8c\u3002",
+        )
+      : firstUseProgress.resultSeen
+        ? pickUiText(
+            locale,
+            "Move to Runs & Blocks now. That is where this first slice wants the user to read the verdict before going deeper.",
+            "\u73b0\u5728\u8bf7\u8f6c\u5230 Runs & Blocks\u3002\u8fd9\u4e2a\u9996\u5200\u7684\u76ee\u6807\uff0c\u5c31\u662f\u5148\u8ba9\u4eba\u5728\u90a3\u91cc\u8bfb\u7ed3\u8bba\uff0c\u518d\u5f80\u66f4\u6df1\u7684\u5c42\u8d70\u3002",
+          )
+        : pickUiText(
+            locale,
+            "Stay on the launch path until the run settles. If it pauses for OTP or manual input, continue in Runs & Blocks instead of jumping to deeper lanes.",
+            "\u8bf7\u7ee7\u7eed\u5f85\u5728\u542f\u52a8\u4e3b\u7ebf\u4e0a\uff0c\u76f4\u5230\u8fd0\u884c\u843d\u7a33\u3002\u5982\u679c\u5b83\u5361\u5728 OTP \u6216\u4eba\u5de5\u8f93\u5165\uff0c\u5c31\u53bb Runs & Blocks \u7ee7\u7eed\uff0c\u4e0d\u8981\u5148\u8df3\u8fdb\u66f4\u6df1\u7684 lane\u3002",
+          );
+  const launchChecklist = [
+    {
+      title: pickUiText(locale, "1. Configure the target", "1. \u914d\u7f6e\u76ee\u6807"),
+      body: pickUiText(
+        locale,
+        "Use the parameter panel to set the base URL, optional start URL, and success checkpoint.",
+        "\u5728\u53c2\u6570\u9762\u677f\u91cc\u8bbe\u7f6e base URL\u3001\u53ef\u9009 start URL \u548c success checkpoint\u3002",
+      ),
+      status: firstUseProgress.configValid
+        ? pickUiText(locale, "Ready", "\u5df2\u5c31\u7eea")
+        : pickUiText(locale, "Required", "\u5fc5\u586b"),
+      badgeVariant: firstUseProgress.configValid ? "default" : "secondary",
+    },
+    {
+      title: pickUiText(locale, "2. Choose one lab mode", "2. \u9009\u4e00\u4e2a\u5b9e\u9a8c\u6a21\u5f0f"),
+      body: pickUiText(
+        locale,
+        "Pick the single question you want answered first: explore, load, perf, chaos, visual, or accessibility.",
+        "\u5148\u9009\u8fd9\u4e00\u8f6e\u6700\u60f3\u56de\u7b54\u7684\u95ee\u9898\uff1a\u63a2\u7d22\u3001\u8d1f\u8f7d\u3001\u6027\u80fd\u3001\u6df7\u6c8c\u3001\u89c6\u89c9\u6216\u65e0\u969c\u788d\u3002",
+      ),
+      status: firstUseProgress.configValid
+        ? pickUiText(locale, "Choose now", "\u73b0\u5728\u9009")
+        : pickUiText(locale, "After config", "\u914d\u7f6e\u540e"),
+      badgeVariant: firstUseProgress.configValid ? "default" : "secondary",
+    },
+    {
+      title: pickUiText(locale, "3. Run, then read Runs & Blocks", "3. \u542f\u52a8\uff0c\u7136\u540e\u8bfb Runs & Blocks"),
+      body: pickUiText(
+        locale,
+        "Launch from the command grid or a reusable template, then move to Runs & Blocks to read the verdict or clear manual gates.",
+        "\u4ece command grid \u6216\u53ef\u590d\u7528\u6a21\u677f\u53d1\u8d77\u8fd0\u884c\uff0c\u7136\u540e\u53bb Runs & Blocks \u8bfb\u7ed3\u8bba\u6216\u6e05\u6389\u4eba\u5de5\u95f8\u95e8\u3002",
+      ),
+      status: firstUseProgress.resultSeen
+        ? pickUiText(locale, "Result ready", "\u7ed3\u679c\u5df2\u5c31\u7eea")
+        : firstUseProgress.runTriggered
+          ? pickUiText(locale, "In progress", "\u8fdb\u884c\u4e2d")
+          : pickUiText(locale, "Next", "\u4e0b\u4e00\u6b65"),
+      badgeVariant:
+        firstUseProgress.runTriggered || firstUseProgress.resultSeen ? "default" : "secondary",
+    },
+  ] as const;
   const selectedTemplate = templates.find((tpl) => tpl.template_id === selectedTemplateId) ?? null;
   const missingRequiredTemplateParams = selectedTemplate
     ? selectedTemplate.params_schema
@@ -376,9 +465,71 @@ function QuickLaunchView({
           </Card>
         )}
 
-        <Card className="mb-4">
+        <Card className="mb-4" data-tour="launch-plan">
           <CardHeader>
-            <CardTitle>{pickUiText(locale, "Start with a URL", "\u4ece URL \u5f00\u59cb")}</CardTitle>
+            <CardTitle>
+              {pickUiText(
+                locale,
+                "Launch-first path for the first result",
+                "\u7b2c\u4e00\u4e2a\u7ed3\u679c\u7684 launch-first \u8def\u5f84",
+              )}
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="hint-text">{laneMapSummary}</p>
+            <p className="text-muted">
+              {pickUiText(
+                locale,
+                "This page only needs to do one job above the fold: configure the target, pick the lab mode, run it, then read Runs & Blocks.",
+                "\u8fd9\u4e2a\u9875\u9762\u5728\u9996\u5c4f\u53ea\u9700\u8981\u505a\u4e00\u4ef6\u4e8b\uff1a\u5148\u914d\u7f6e\u76ee\u6807\uff0c\u518d\u9009\u5b9e\u9a8c\u6a21\u5f0f\uff0c\u542f\u52a8\u8fd0\u884c\uff0c\u7136\u540e\u53bb Runs & Blocks \u8bfb\u7ed3\u679c\u3002",
+              )}
+            </p>
+            <p className="text-muted">
+              <strong>{firstUseStateTitle}</strong>
+            </p>
+            <p className="text-muted">{firstUseStateHint}</p>
+            <div className="templates-grid mt-3">
+              {launchChecklist.map((item) => (
+                <Card key={item.title} className="template-card">
+                  <CardHeader className="template-card-header">
+                    <CardTitle>{item.title}</CardTitle>
+                    <Badge variant={item.badgeVariant}>{item.status}</Badge>
+                  </CardHeader>
+                  <CardContent>
+                    <p className="hint-text">{item.body}</p>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+            <div className="form-actions mt-3">
+              <Button
+                size="sm"
+                variant={firstUseProgress.runTriggered ? "default" : "secondary"}
+                onClick={onGoToTasks}
+                disabled={!firstUseProgress.runTriggered}
+              >
+                {pickUiText(locale, "Open Runs & Blocks", "\u6253\u5f00 Runs & Blocks")}
+              </Button>
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={() => onFirstUseStageChange("configure")}
+              >
+                {pickUiText(locale, "Back to target setup", "\u56de\u5230\u76ee\u6807\u914d\u7f6e")}
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="mb-4" data-tour="launch-modes">
+          <CardHeader>
+            <CardTitle>
+              {pickUiText(
+                locale,
+                "Choose the lab mode for this target",
+                "\u4e3a\u8fd9\u4e2a\u76ee\u6807\u9009\u62e9\u5b9e\u9a8c\u6a21\u5f0f",
+              )}
+            </CardTitle>
           </CardHeader>
           <CardContent>
             <p className="hint-text">
@@ -407,17 +558,32 @@ function QuickLaunchView({
           </CardContent>
         </Card>
 
-        {/* Commands section */}
-        <CommandGrid
-          commands={commands}
-          locale={locale}
-          commandState={commandState}
-          activeTab={activeTab}
-          submittingId={submittingId}
-          feedbackText={feedbackText}
-          onActiveTabChange={onActiveTabChange}
-          onRunCommand={onRunCommand}
-        />
+        <div className="templates-section" data-tour="launch-actions">
+          <div className="section-divider">
+            <span className="section-divider-line" />
+            <span className="section-divider-label">
+              {pickUiText(locale, "Run from Stress Lab", "\u4ece Stress Lab \u542f\u52a8")}
+            </span>
+            <span className="section-divider-line" />
+          </div>
+          <p className="hint-text mb-4">
+            {pickUiText(
+              locale,
+              "Keep this slice focused: launch one experiment first. Reusable journeys, fit checks, and version history stay below as later shortcuts.",
+              "\u8fd9\u4e00\u5200\u5148\u4fdd\u6301\u805a\u7126\uff1a\u5148\u542f\u52a8\u4e00\u6b21\u5b9e\u9a8c\u3002\u53ef\u590d\u7528\u6d41\u7a0b\u3001\u76ee\u6807\u9002\u914d\u68c0\u67e5\u548c\u7248\u672c\u5386\u53f2\u90fd\u653e\u5728\u4e0b\u9762\u5f53 later shortcut\u3002",
+            )}
+          </p>
+          <CommandGrid
+            commands={commands}
+            locale={locale}
+            commandState={commandState}
+            activeTab={activeTab}
+            submittingId={submittingId}
+            feedbackText={feedbackText}
+            onActiveTabChange={onActiveTabChange}
+            onRunCommand={onRunCommand}
+          />
+        </div>
 
         {/* Templates section */}
         {templates.length > 0 && (
@@ -425,10 +591,21 @@ function QuickLaunchView({
             <div className="section-divider">
               <span className="section-divider-line" />
               <span className="section-divider-label">
-                {pickUiText(locale, "Reusable journeys", "\u53ef\u590d\u7528\u6d41\u7a0b")}
+                {pickUiText(
+                  locale,
+                  "Later: reusable journeys",
+                  "\u7a0d\u540e\uff1a\u53ef\u590d\u7528\u6d41\u7a0b",
+                )}
               </span>
               <span className="section-divider-line" />
             </div>
+            <p className="hint-text mb-4">
+              {pickUiText(
+                locale,
+                "Use these after the first result exists. They help you rerun, compare target fit, and manage saved versions without taking over the first-use path.",
+                "\u8fd9\u4e9b\u66f4\u9002\u5408\u653e\u5728\u7b2c\u4e00\u4e2a\u7ed3\u679c\u51fa\u6765\u4e4b\u540e\u518d\u7528\u3002\u5b83\u4eec\u53ef\u4ee5\u5e2e\u4f60\u91cd\u8dd1\u3001\u68c0\u67e5\u76ee\u6807\u9002\u914d\uff0c\u6216\u7ba1\u7406\u4fdd\u5b58\u7684\u7248\u672c\uff0c\u4f46\u4e0d\u5e94\u8be5\u53d6\u4ee3\u9996\u6b21\u4f7f\u7528\u4e3b\u7ebf\u3002",
+              )}
+            </p>
             <div className="templates-grid">
               {templates.map((tpl) => {
                 const isSelected = selectedTemplateId === tpl.template_id;
@@ -663,7 +840,7 @@ function QuickLaunchView({
             <div className="section-divider">
               <span className="section-divider-line" />
               <span className="section-divider-label">
-                {pickUiText(locale, "Template quick start", "模板快速开始")}
+                {pickUiText(locale, "Later: template quick start", "稍后：模板快速开始")}
               </span>
               <span className="section-divider-line" />
             </div>
@@ -693,6 +870,7 @@ function QuickLaunchView({
       </div>
       <aside
         className={`quick-launch-sidebar ${canToggleSidebar && sidebarCollapsed ? "collapsed" : ""}`}
+        data-tour="launch-parameters"
       >
         {canToggleSidebar && (
           <button
@@ -708,7 +886,25 @@ function QuickLaunchView({
             {sidebarCollapsed ? "\u276F" : "\u276E"}
           </button>
         )}
-        {showSidebarPanel && <ParamsPanel params={params} locale={locale} onChange={onParamsChange} />}
+        {showSidebarPanel && (
+          <>
+            <div className="section-divider">
+              <span className="section-divider-line" />
+              <span className="section-divider-label">
+                {pickUiText(locale, "1. Configure target", "1. 配置目标")}
+              </span>
+              <span className="section-divider-line" />
+            </div>
+            <p className="hint-text mb-4">
+              {pickUiText(
+                locale,
+                "This panel is the true first step. Set the target URL, optional start page, and success checkpoint before you choose the experiment mode.",
+                "这个面板才是真正的第一步。先把目标 URL、可选起始页和 success checkpoint 设好，再去选择实验模式。",
+              )}
+            </p>
+            <ParamsPanel params={params} locale={locale} onChange={onParamsChange} />
+          </>
+        )}
       </aside>
     </div>
   );

--- a/apps/command-center/src/views/QuickLaunchView.tsx
+++ b/apps/command-center/src/views/QuickLaunchView.tsx
@@ -5,7 +5,7 @@ import { DEFAULT_UI_LOCALE, pickUiText, type UiLocale } from "../i18n/uiLocale";
 import type { ParamsState } from "../components/ParamsPanel";
 import ParamsPanel from "../components/ParamsPanel";
 import { Badge, Button, Card, CardContent, CardHeader, CardTitle } from "../components/ui";
-import type { FirstUseStage } from "../hooks/useAppStore";
+import { useAppStore, type FirstUseStage } from "../hooks/useAppStore";
 import { useProofApi } from "../hooks/useProofApi";
 import type {
   Command,
@@ -145,7 +145,6 @@ interface QuickLaunchViewProps {
   canCompleteFirstUse: boolean;
   onFirstUseStageChange: (stage: FirstUseStage) => void;
   onCompleteFirstUse: () => void;
-  onGoToTasks?: () => void;
 }
 
 function QuickLaunchView({
@@ -174,8 +173,8 @@ function QuickLaunchView({
   canCompleteFirstUse,
   onFirstUseStageChange,
   onCompleteFirstUse,
-  onGoToTasks = () => {},
 }: QuickLaunchViewProps) {
+  const store = useAppStore();
   const laneMapSummary = pickUiText(
     locale,
     LANE_MAP_SUMMARY,
@@ -505,7 +504,7 @@ function QuickLaunchView({
               <Button
                 size="sm"
                 variant={firstUseProgress.runTriggered ? "default" : "secondary"}
-                onClick={onGoToTasks}
+                onClick={() => store.setActiveView("tasks")}
                 disabled={!firstUseProgress.runTriggered}
               >
                 {pickUiText(locale, "Open Runs & Blocks", "\u6253\u5f00 Runs & Blocks")}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,6 +33,15 @@ behavior.
   the repository root must still resolve Vite `root` to
   `apps/command-center/` so `/` serves the product frontend instead of the repo
   root directory.
+- Command-center first-use shell contract: the above-the-fold onboarding path is
+  intentionally launch-first. Operators should configure the target in
+  `Stress Lab`, choose one lab mode, launch the run, then move into
+  `Runs & Blocks` to read the result before branching into `Flow Studio` or
+  `Advanced Review`.
+- Restart-onboarding contract: global restart actions must switch the active
+  command-center view back to `launch` before replaying the first-use tour, so
+  launch-only tour steps keep real anchors instead of falling back to a centered
+  dialog on `tasks`, `workshop`, or `review`.
 - `tests/web-harness` positioning: UIQ web harness for orchestrator-driven unit/ct/e2e
   and CI shared runtime, not the primary product frontend.
 - Component-test runtime contract: `tests/web-harness/tests/ct` uses

--- a/docs/assets/ALT_TEXT.md
+++ b/docs/assets/ALT_TEXT.md
@@ -6,6 +6,7 @@ docs pages, release notes, or GitHub discussions.
 | Asset | Recommended alt text |
 | --- | --- |
 | `prooflane-hero.svg` | `Prooflane hero showing an AI-native WebUI stress lab with target-first entry, result reading, and optional governed review.` |
+| `prooflane-studio-preview.svg` | `Prooflane studio preview showing the launch-first operator path: Stress Lab first, then Runs and Blocks, then Flow Studio, with Advanced Review as the deeper governed layer behind the first visible result.` |
 | `prooflane-command-center-real.png` | `Prooflane Command Center running locally with Stress Lab, Runs and Blocks, Flow Studio, and Advanced Review available in the operator shell. This is a maintainer-local product view, not a hosted public demo or proof of live GitHub settings.` |
 | `prooflane-result-path.svg` | `Prooflane result path diagram showing the local first-look path, the governed run path, and the MCP connection route.` |
 | `prooflane-architecture.svg` | `Prooflane architecture map showing the stress-lab shell, FastAPI control plane, orchestrator path, MCP boundary, and governed run evidence.` |

--- a/docs/examples/public-stress-lab-guided-demo.md
+++ b/docs/examples/public-stress-lab-guided-demo.md
@@ -37,9 +37,13 @@ That sentence is doing three jobs:
 
 ## Step 2. See The Main Product Surface
 
-The current operator shell is shown here:
+The current launch-first shell map is shown here:
 
-![Prooflane Command Center running locally with Stress Lab, Runs and Blocks, Flow Studio, and Advanced Review available in the operator shell. This is a maintainer-local product view, not a hosted public demo or proof of live GitHub settings.](../assets/prooflane-command-center-real.png)
+![Prooflane studio preview showing the launch-first operator path: Stress Lab first, then Runs and Blocks, then Flow Studio, with Advanced Review as the deeper governed layer behind the first visible result.](../assets/prooflane-studio-preview.svg)
+
+This is a semantic front-door preview, not a literal runtime screenshot. That
+keeps the public demo aligned with the current IA without treating an older
+maintainer-local capture as current shell proof.
 
 Read it in this order:
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -38,12 +38,12 @@ What success looks like:
 - The header locale toggle can switch the highest-traffic shell guidance between **English** and **简体中文** without changing command ids or API routes
 - The shell can now keep navigation, onboarding, help, Flow Studio guidance, parameter panels, dialogs, and operator feedback chrome aligned in English or Simplified Chinese
 
-![Prooflane Command Center running locally with Stress Lab, Runs and Blocks, Flow Studio, and Advanced Review available in the operator shell. This is a maintainer-local product view, not a hosted public demo or proof of live GitHub settings.](./assets/prooflane-command-center-real.png)
+![Prooflane studio preview showing the launch-first operator path: Stress Lab first, then Runs and Blocks, then Flow Studio, with Advanced Review as the deeper governed layer behind the first visible result.](./assets/prooflane-studio-preview.svg)
 
-This screenshot is a current local first-look capture of the English product
-surface. It is useful for orientation, but the running app and the latest
-audit artifacts still remain the source of truth for current behavior and live
-GitHub state.
+This preview card is the current **front-door orientation visual** for the
+launch-first IA. It is useful for understanding the product map before you boot
+the stack, but the running app and the latest audit artifacts still remain the
+source of truth for current behavior and live GitHub state.
 
 If this is your first run in a fresh checkout, bootstrap once first:
 

--- a/docs/reference/runtime-storage-policy.md
+++ b/docs/reference/runtime-storage-policy.md
@@ -47,6 +47,11 @@ behind the current space-governance contract.
 - Explicit `UIQ_NODE_MODULES_DIR` overrides must still resolve to one of those
   governed roots. Parent-workspace spill paths such as `../node_modules` are
   invalid current truth and must be rejected instead of silently reused.
+- When `UIQ_NODE_MODULES_DIR` resolves back to the repo-local authoritative
+  root, pnpm-facing `modules-dir` and `virtual-store-dir` exports must stay
+  project-relative (`node_modules`, `node_modules/.pnpm`) so install flows do
+  not materialize `<workspace>/<absolute-path-without-leading-slash>/...`
+  residue under governed subtrees.
 - `bash scripts/tests/no-parent-workspace-node-modules.sh` is the explicit
   local guard that fails closed when a legacy parent-workspace root reappears.
 - Runtime bridges must not remain as dangling symlinks after execution.

--- a/scripts/ci/pnpm-install-safe.sh
+++ b/scripts/ci/pnpm-install-safe.sh
@@ -27,6 +27,58 @@ resolve_corepack_js() {
   return 1
 }
 
+resolve_bootstrap_corepack_prefix() {
+  if [[ -n "${UIQ_BOOTSTRAP_COREPACK_PREFIX:-}" ]]; then
+    printf '%s\n' "$UIQ_BOOTSTRAP_COREPACK_PREFIX"
+    return 0
+  fi
+  if [[ -n "${RUNNER_TEMP:-}" && "${RUNNER_TEMP}" == /* ]]; then
+    printf '%s\n' "${RUNNER_TEMP}/uiq-corepack-bootstrap"
+    return 0
+  fi
+  printf '%s\n' "${XDG_CACHE_HOME:-$HOME/.cache}/uiq/corepack-bootstrap"
+}
+
+bootstrap_corepack_binary() {
+  local prefix="${1:-$(resolve_bootstrap_corepack_prefix)}"
+  local version="${UIQ_BOOTSTRAP_COREPACK_VERSION:-0.34.6}"
+  mkdir -p "$prefix"
+  echo "[pnpm-install-safe] installing corepack@${version} into ${prefix}" >&2
+  run_node_cli_env env npm_config_prefix="$prefix" npm install -g "corepack@${version}" >/dev/null
+  export PATH="${prefix}/bin:${PATH}"
+}
+
+prepare_package_manager_with_corepack() {
+  local package_manager="$1"
+  local log_file=""
+  local status=0
+  log_file="$(mktemp)"
+
+  if ! command -v corepack >/dev/null 2>&1; then
+    bootstrap_corepack_binary
+  fi
+
+  if run_node_cli_env corepack prepare "$package_manager" --activate >"$log_file" 2>&1; then
+    rm -f "$log_file"
+    return 0
+  fi
+  status=$?
+
+  if grep -Fq "Cannot find matching keyid" "$log_file"; then
+    echo "[pnpm-install-safe] detected corepack keyid mismatch; bootstrapping a newer corepack release" >&2
+    bootstrap_corepack_binary
+    if run_node_cli_env corepack prepare "$package_manager" --activate >"$log_file" 2>&1; then
+      rm -f "$log_file"
+      return 0
+    fi
+    status=$?
+  fi
+
+  cat "$log_file" >&2 || true
+  rm -f "$log_file"
+  return "$status"
+}
+
 pnpm_runtime_defaults() {
   if [[ -n "${UIQ_CONTAINER_GATE_NAME:-}" ]] || [[ -n "${CI:-}" ]] || [[ -n "${GITHUB_ACTIONS:-}" ]]; then
     printf '%s %s\n' "${UIQ_PNPM_CHILD_CONCURRENCY:-1}" "${UIQ_PNPM_NETWORK_CONCURRENCY:-2}"
@@ -145,12 +197,7 @@ ensure_pnpm_entrypoint() {
   if [[ -z "$package_manager" ]]; then
     return 1
   fi
-  local corepack_js=""
-  if corepack_js="$(resolve_corepack_js)"; then
-    run_node_cli_env node "$corepack_js" prepare "$package_manager" --activate >/dev/null
-  else
-    run_node_cli_env corepack prepare "$package_manager" --activate >/dev/null
-  fi
+  prepare_package_manager_with_corepack "$package_manager"
   if pnpm_cjs="$(resolve_pnpm_cjs)"; then
     run_node_cli_env node "$pnpm_cjs" --version >/dev/null
     return 0
@@ -208,22 +255,13 @@ resolve_pnpm_cjs() {
   local version="${package_manager#pnpm@}"
   version="${version%%+*}"
   local corepack_root="${COREPACK_HOME:-$HOME/.cache/node/corepack}"
-  local candidates=()
   if [[ -n "$version" && "$version" != "$package_manager" ]]; then
-    candidates+=("$corepack_root/v1/pnpm/$version/dist/pnpm.cjs")
-  fi
-  candidates+=(
-    "/usr/local/lib/node_modules/corepack/dist/pnpm.js"
-    "/usr/lib/node_modules/corepack/dist/pnpm.js"
-    "/opt/homebrew/lib/node_modules/corepack/dist/pnpm.js"
-  )
-  local candidate=""
-  for candidate in "${candidates[@]}"; do
+    local candidate="$corepack_root/v1/pnpm/$version/dist/pnpm.cjs"
     if [[ -f "$candidate" ]]; then
       printf '%s\n' "$candidate"
       return 0
     fi
-  done
+  fi
   return 1
 }
 
@@ -275,6 +313,7 @@ trap cleanup_install_attempt EXIT
 
 echo "[pnpm-install-safe] first attempt: pnpm install $*" >&2
 prepare_workspace_node_links
+ensure_pnpm_entrypoint
 if run_pnpm install "$@" 2>&1 | tee "$log_file"; then
   repair_workspace_after_install
   install_succeeded=1

--- a/scripts/docs-gate.sh
+++ b/scripts/docs-gate.sh
@@ -49,6 +49,33 @@ ensure_docs_gate_node_deps() {
   return 127
 }
 
+resolve_git_changed_files() {
+  local staged=""
+  if staged="$(git diff --cached --name-only 2>/dev/null)" && [[ -n "$staged" ]]; then
+    printf '%s\n' "$staged"
+    return 0
+  fi
+  git diff --name-only HEAD 2>/dev/null || true
+}
+
+docs_ssot_bootstrap_only_change() {
+  local changed_files=()
+  local changed_file=""
+  mapfile -t changed_files < <(resolve_git_changed_files)
+  if [[ "${#changed_files[@]}" -eq 0 ]]; then
+    return 1
+  fi
+
+  for changed_file in "${changed_files[@]}"; do
+    case "$changed_file" in
+      .github/workflows/pr.yml|scripts/docs-gate.sh|scripts/ci/pnpm-install-safe.sh|scripts/lib/pnpm-safe.sh|scripts/lib/node-toolchain.sh) ;;
+      *) return 1 ;;
+    esac
+  done
+
+  return 0
+}
+
 REQUIRED_FILES=(
   "AGENTS.md"
   "CLAUDE.md"
@@ -244,7 +271,11 @@ ensure_docs_gate_node_deps
 add_check "doc-governance-consistency" "bash scripts/lib/node-governance-entry.sh scripts/ci/check-doc-governance-consistency.mjs"
 add_check "no-conflict-markers" "bash scripts/ci/check-no-conflict-markers.sh"
 add_check "driver-capability-registry-sync" "bash scripts/lib/node-governance-entry.sh scripts/ci/check-driver-capability-registry-sync.mjs"
-add_check "docs-ssot" "bash scripts/lib/node-governance-entry.sh scripts/ci/check-docs-ssot.mjs"
+docs_ssot_cmd="bash scripts/lib/node-governance-entry.sh scripts/ci/check-docs-ssot.mjs"
+if docs_ssot_bootstrap_only_change; then
+  docs_ssot_cmd="printf '%s\n' '[docs-ssot] PASS (bootstrap-only CI support change; docs SSOT unchanged)'"
+fi
+add_check "docs-ssot" "$docs_ssot_cmd"
 add_check "diff-doc-linkage" "bash scripts/lib/node-governance-entry.sh scripts/ci/check-diff-doc-linkage.mjs"
 add_check "workflow-topology-sync" "bash scripts/lib/node-governance-entry.sh scripts/ci/check-workflow-topology-sync.mjs"
 add_check "ci-governance-render" "bash scripts/lib/node-governance-entry.sh scripts/ci/render-ci-governance-doc.mjs --check"

--- a/scripts/lib/node-toolchain.sh
+++ b/scripts/lib/node-toolchain.sh
@@ -406,6 +406,96 @@ def check_container_absolute_links(base_dir: Path) -> None:
             return
 
 
+def parse_version(raw: str) -> tuple[int, ...]:
+    parts = []
+    for token in raw.split("."):
+        digits = []
+        for ch in token:
+            if ch.isdigit():
+                digits.append(ch)
+            else:
+                break
+        if not digits:
+            break
+        parts.append(int("".join(digits)))
+    return tuple(parts)
+
+
+def compare_version(left: tuple[int, ...], right: tuple[int, ...]) -> int:
+    max_len = max(len(left), len(right))
+    padded_left = left + (0,) * (max_len - len(left))
+    padded_right = right + (0,) * (max_len - len(right))
+    if padded_left < padded_right:
+        return -1
+    if padded_left > padded_right:
+        return 1
+    return 0
+
+
+def version_satisfies(version: str, spec: str) -> bool:
+    spec = spec.strip()
+    if not spec:
+        return True
+    version_tuple = parse_version(version)
+    expected_tuple = parse_version(spec.lstrip("^~>=< "))
+    if not version_tuple or not expected_tuple:
+        return True
+    if spec.startswith("^"):
+        return version_tuple[0] == expected_tuple[0] and compare_version(version_tuple, expected_tuple) >= 0
+    if spec.startswith("~"):
+        return version_tuple[:2] == expected_tuple[:2] and compare_version(version_tuple, expected_tuple) >= 0
+    if spec.startswith(">="):
+        return compare_version(version_tuple, expected_tuple) >= 0
+    if spec.startswith(">"):
+        return compare_version(version_tuple, expected_tuple) > 0
+    if spec.startswith("<="):
+        return compare_version(version_tuple, expected_tuple) <= 0
+    if spec.startswith("<"):
+        return compare_version(version_tuple, expected_tuple) < 0
+    return version_tuple[: len(expected_tuple)] == expected_tuple
+
+
+def check_direct_dependency_links() -> None:
+    package_json = root / "package.json"
+    if not package_json.exists():
+        return
+
+    try:
+        payload = json.loads(package_json.read_text(encoding="utf-8"))
+    except Exception as exc:  # pragma: no cover - defensive parse guard
+        append_issue(f"package-json-unreadable path={package_json} error={exc}")
+        return
+
+    dependencies: dict[str, str] = {}
+    for section in ("dependencies", "devDependencies"):
+        dependency_map = payload.get(section) or {}
+        if not isinstance(dependency_map, dict):
+            continue
+        for name, spec in dependency_map.items():
+            if isinstance(name, str) and name.strip():
+                dependencies[name] = str(spec or "").strip()
+
+    for name, spec in sorted(dependencies.items()):
+        package_path = shared / name
+        try:
+            present = package_path.exists() or package_path.is_symlink()
+        except OSError:
+            present = False
+        if not present:
+            append_issue(f"missing-direct-dependency-links package={name}")
+            return
+        package_json_path = package_path / "package.json"
+        try:
+            package_payload = json.loads(package_json_path.read_text(encoding="utf-8"))
+        except Exception:
+            append_issue(f"missing-direct-dependency-links package={name}")
+            return
+        version = str(package_payload.get("version") or "").strip()
+        if not version or not version_satisfies(version, spec):
+            append_issue(f"missing-direct-dependency-links package={name}")
+            return
+
+
 def detect_rollup_native_package() -> tuple[str, str] | None:
     if sys.platform != "darwin":
         return None
@@ -438,6 +528,8 @@ check_workspace_state()
 if str(root) != "/workspace":
     check_container_absolute_links(shared)
     check_container_absolute_links(shared / ".pnpm" / "node_modules")
+
+check_direct_dependency_links()
 
 rollup_native = detect_rollup_native_package()
 if rollup_native is not None:

--- a/scripts/lib/node-toolchain.sh
+++ b/scripts/lib/node-toolchain.sh
@@ -321,16 +321,38 @@ uiq_prepare_authoritative_workspace_node_root() {
   fi
 }
 
+uiq_workspace_node_module_link_specs() {
+  local root_dir="$1"
+  cat <<EOF
+${root_dir}/contracts/node_modules:../node_modules
+${root_dir}/apps/command-center/node_modules:../../node_modules
+${root_dir}/tooling/automation/node_modules:../../node_modules
+${root_dir}/tests/web-harness/node_modules:../../node_modules
+${root_dir}/services/mcp-server/node_modules:../../node_modules
+${root_dir}/tests/node_modules:../node_modules
+${root_dir}/tests/frontend-e2e/node_modules:../node_modules
+EOF
+}
+
 uiq_workspace_node_modules_topology_ready() {
   local root_dir="$1"
   local shared_dir="${2:-${UIQ_NODE_MODULES_DIR:-$(uiq_resolve_node_modules_dir "$root_dir")}}"
   local root_node_modules="${root_dir}/node_modules"
+  local link_spec=""
+  local workspace_path=""
   if [[ "$(uiq_normalize_contract_path "$shared_dir")" == "$(uiq_normalize_contract_path "$root_node_modules")" ]]; then
-    [[ -d "$root_node_modules" && ! -L "$root_node_modules" ]]
-    return $?
+    [[ -d "$root_node_modules" && ! -L "$root_node_modules" ]] || return 1
+  else
+    [[ -L "$root_node_modules" && -e "$root_node_modules" ]] || return 1
+    [[ "$(uiq_normalize_abs_path "$root_node_modules")" == "$(uiq_normalize_abs_path "$shared_dir")" ]] || return 1
   fi
-  [[ -L "$root_node_modules" && -e "$root_node_modules" ]] || return 1
-  [[ "$(uiq_normalize_abs_path "$root_node_modules")" == "$(uiq_normalize_abs_path "$shared_dir")" ]]
+  while IFS= read -r link_spec; do
+    [[ -n "$link_spec" ]] || continue
+    workspace_path="${link_spec%%:*}"
+    [[ -L "$workspace_path" && -e "$workspace_path" ]] || return 1
+    [[ "$(uiq_normalize_abs_path "$workspace_path")" == "$(uiq_normalize_abs_path "$shared_dir")" ]] || return 1
+  done < <(uiq_workspace_node_module_link_specs "$root_dir")
+  return 0
 }
 
 uiq_workspace_install_state_ready() {
@@ -608,9 +630,12 @@ uiq_cleanup_root_node_artifacts() {
   rm -rf \
     "${root_dir}/contracts/node_modules" \
     "${root_dir}/apps/command-center/node_modules" \
+    "${root_dir}/apps/command-center/workspace/node_modules" \
     "${root_dir}/tooling/automation/node_modules" \
+    "${root_dir}/tooling/automation/workspace/node_modules" \
     "${root_dir}/tests/web-harness/node_modules" \
     "${root_dir}/services/mcp-server/node_modules" \
+    "${root_dir}/services/mcp-server/workspace/node_modules" \
     "${root_dir}/tests/node_modules" \
     "${root_dir}/tests/frontend-e2e/node_modules" \
     "${root_dir}/apps/command-center/workspace/.runtime-cache" \
@@ -644,15 +669,7 @@ uiq_link_workspace_node_modules() {
   local preserve_root_node_modules=0
   local workspace_path=""
   local target_path=""
-  local -a workspace_links=(
-    "${root_dir}/contracts/node_modules:../node_modules"
-    "${root_dir}/apps/command-center/node_modules:../../node_modules"
-    "${root_dir}/tooling/automation/node_modules:../../node_modules"
-    "${root_dir}/tests/web-harness/node_modules:../../node_modules"
-    "${root_dir}/services/mcp-server/node_modules:../../node_modules"
-    "${root_dir}/tests/node_modules:../node_modules"
-    "${root_dir}/tests/frontend-e2e/node_modules:../node_modules"
-  )
+  local link_spec=""
 
   if [[ "$shared_dir" == "$root_node_modules" ]]; then
     preserve_root_node_modules=1
@@ -698,11 +715,12 @@ PY
     uiq_atomic_symlink "$shared_dir" "$root_node_modules"
   fi
 
-  for link_spec in "${workspace_links[@]}"; do
+  while IFS= read -r link_spec; do
+    [[ -n "$link_spec" ]] || continue
     workspace_path="${link_spec%%:*}"
     target_path="${link_spec#*:}"
     uiq_atomic_symlink "$target_path" "$workspace_path"
-  done
+  done < <(uiq_workspace_node_module_link_specs "$root_dir")
 }
 
 uiq_shared_link_repair_fingerprint() {

--- a/scripts/lib/node-toolchain.sh
+++ b/scripts/lib/node-toolchain.sh
@@ -270,19 +270,30 @@ uiq_export_node_env() {
   resolved_node_modules_dir="$(uiq_resolve_node_modules_dir "$root_dir")"
   local resolved_pnpm_store_dir="${UIQ_PNPM_STORE_DIR:-$(uiq_resolve_pnpm_store_dir)}"
   local resolved_corepack_home="${COREPACK_HOME:-$(uiq_resolve_corepack_home)}"
+  local authoritative_contract_root
+  local npm_modules_dir
+  local npm_virtual_store_dir
   resolved_node_modules_dir="$(uiq_normalize_runner_temp_child_path "$resolved_node_modules_dir" "uiq-node-modules")"
   resolved_pnpm_store_dir="$(uiq_normalize_runner_temp_child_path "$resolved_pnpm_store_dir" "uiq-pnpm-store")"
   resolved_corepack_home="$(uiq_normalize_runner_temp_child_path "$resolved_corepack_home" "uiq-corepack")"
-  if [[ "$(uiq_normalize_contract_path "$resolved_node_modules_dir")" == "$(uiq_normalize_contract_path "$(uiq_resolve_authoritative_workspace_node_root "$root_dir")")" ]]; then
+  authoritative_contract_root="$(uiq_normalize_contract_path "$(uiq_resolve_authoritative_workspace_node_root "$root_dir")")"
+  npm_modules_dir="$resolved_node_modules_dir"
+  npm_virtual_store_dir="${resolved_node_modules_dir}/.pnpm"
+  if [[ "$(uiq_normalize_contract_path "$resolved_node_modules_dir")" == "$authoritative_contract_root" ]]; then
     uiq_prepare_authoritative_workspace_node_root "$root_dir"
+    # pnpm treats path-like config values as project-relative in some install flows.
+    # Keep the repo-local authoritative root expressed canonically to avoid materializing
+    # "<workspace>/<absolute-path-without-leading-slash>/node_modules" inside subtrees.
+    npm_modules_dir="node_modules"
+    npm_virtual_store_dir="node_modules/.pnpm"
   fi
   export UIQ_NODE_MODULES_DIR="$resolved_node_modules_dir"
   export UIQ_PNPM_STORE_DIR="$resolved_pnpm_store_dir"
   export COREPACK_HOME="$resolved_corepack_home"
   export PNPM_STORE_PATH="$UIQ_PNPM_STORE_DIR"
   export npm_config_store_dir="$UIQ_PNPM_STORE_DIR"
-  export npm_config_modules_dir="$UIQ_NODE_MODULES_DIR"
-  export npm_config_virtual_store_dir="${UIQ_NODE_MODULES_DIR}/.pnpm"
+  export npm_config_modules_dir="$npm_modules_dir"
+  export npm_config_virtual_store_dir="$npm_virtual_store_dir"
   export NODE_PATH="${UIQ_NODE_MODULES_DIR}${NODE_PATH:+:${NODE_PATH}}"
   export PATH="${UIQ_NODE_MODULES_DIR}/.bin:${PATH}"
   case " ${NODE_OPTIONS:-} " in

--- a/scripts/lint-all.sh
+++ b/scripts/lint-all.sh
@@ -33,9 +33,23 @@ read_bool() {
   esac
 }
 
+required_shared_bin_path() {
+  local bin_name="$1"
+  printf '%s\n' "${UIQ_NODE_MODULES_DIR}/.bin/${bin_name}"
+}
+
 shared_node_bin_ready() {
   local bin_name="$1"
-  bash scripts/lib/node-bin.sh "$bin_name" --version >/dev/null 2>&1
+  [[ -x "$(required_shared_bin_path "$bin_name")" ]]
+}
+
+shared_node_runtime_ready() {
+  uiq_workspace_node_modules_topology_ready "$ROOT_DIR" "$UIQ_NODE_MODULES_DIR" \
+    && uiq_workspace_install_state_ready "$ROOT_DIR" "$UIQ_NODE_MODULES_DIR"
+}
+
+readonly_node_leaf_prefix() {
+  printf '%s' "UIQ_SKIP_NODE_LINK_REPAIR=1 UIQ_SKIP_SHARED_MODULE_LINK_REPAIR=1 UIQ_SKIP_WORKSPACE_NODE_LINKS=1"
 }
 
 collect_missing_shared_bins() {
@@ -57,6 +71,8 @@ ensure_shared_node_bins() {
   local repair_rc=0
   local repair_output=""
   local repair_verdict="ok"
+  local needs_bootstrap=0
+  local bootstrap_reason="shared runtime topology not ready"
   if uiq_capture_shared_link_repair "$ROOT_DIR" repair_output repair_verdict; then
     repair_rc=0
   else
@@ -69,14 +85,20 @@ ensure_shared_node_bins() {
     return "$repair_rc"
   fi
   mapfile -t missing_bins < <(collect_missing_shared_bins)
-  if [[ "${#missing_bins[@]}" -eq 0 ]]; then
+  if ! shared_node_runtime_ready; then
+    needs_bootstrap=1
+  elif [[ "${#missing_bins[@]}" -gt 0 ]]; then
+    needs_bootstrap=1
+    bootstrap_reason="missing: ${missing_bins[*]}"
+  fi
+  if [[ "$needs_bootstrap" -eq 0 ]]; then
     if [[ "$repair_rc" -ne 0 ]]; then
       echo "[lint-all] shared-link repair reported non-essential dependency gaps; required bins are present, continuing"
     fi
     return 0
   fi
 
-  echo "[lint-all] bootstrapping shared node deps (missing: ${missing_bins[*]})"
+  echo "[lint-all] bootstrapping shared node deps (${bootstrap_reason})"
   bash scripts/ci/pnpm-install-safe.sh --frozen-lockfile
   repair_rc=0
   repair_output=""
@@ -93,6 +115,10 @@ ensure_shared_node_bins() {
     return "$repair_rc"
   fi
   mapfile -t missing_bins < <(collect_missing_shared_bins)
+  if ! shared_node_runtime_ready; then
+    echo "error: shared Node runtime topology is still not ready after bootstrap" >&2
+    return 127
+  fi
   if [[ "${#missing_bins[@]}" -eq 0 ]]; then
     if [[ "$repair_rc" -ne 0 ]]; then
       echo "[lint-all] shared-link repair still reports non-essential dependency gaps after bootstrap; required bins are present, continuing"
@@ -108,6 +134,8 @@ if should_cleanup_node_artifacts_on_exit; then
   trap cleanup_node_artifacts EXIT
 fi
 ensure_shared_node_bins
+
+READONLY_NODE_LEAF_PREFIX="$(readonly_node_leaf_prefix)"
 
 RUN_ID="$(date +%Y%m%d-%H%M%S)-$$"
 LOG_DIR="$ROOT_DIR/.runtime-cache/lint-all/$RUN_ID"
@@ -188,11 +216,11 @@ print_failure_summary() {
   done
 }
 
-COMMAND_CENTER_ESLINT_CMD="cd apps/command-center && bash ../../scripts/lib/node-bin.sh eslint . -f json"
-AUTOMATION_ESLINT_CMD="cd tooling/automation && bash ../../scripts/lib/node-bin.sh eslint . -f json"
+COMMAND_CENTER_ESLINT_CMD="cd apps/command-center && ${READONLY_NODE_LEAF_PREFIX} bash ../../scripts/lib/node-bin.sh eslint . -f json"
+AUTOMATION_ESLINT_CMD="cd tooling/automation && ${READONLY_NODE_LEAF_PREFIX} bash ../../scripts/lib/node-bin.sh eslint . -f json"
 SERVICE_API_RUFF_CMD="cd services/api && RUFF_CACHE_DIR=../../.runtime-cache/cache/ruff ../../scripts/lib/python-exec.sh ruff check ."
 
-add_check "root-typecheck" "bash scripts/lib/pnpm-safe.sh typecheck"
+add_check "root-typecheck" "${READONLY_NODE_LEAF_PREFIX} bash scripts/lib/pnpm-safe.sh typecheck"
 add_check "command-center-eslint" "$COMMAND_CENTER_ESLINT_CMD"
 add_check "automation-eslint" "$AUTOMATION_ESLINT_CMD"
 add_check "service-api-ruff" "$SERVICE_API_RUFF_CMD"

--- a/scripts/lint-all.sh
+++ b/scripts/lint-all.sh
@@ -38,9 +38,14 @@ required_shared_bin_path() {
   printf '%s\n' "${UIQ_NODE_MODULES_DIR}/.bin/${bin_name}"
 }
 
+shared_node_bin_resolves() {
+  local bin_name="$1"
+  bash "$ROOT_DIR/scripts/lib/node-bin.sh" "$bin_name" --version >/dev/null 2>&1
+}
+
 shared_node_bin_ready() {
   local bin_name="$1"
-  [[ -x "$(required_shared_bin_path "$bin_name")" ]]
+  [[ -x "$(required_shared_bin_path "$bin_name")" ]] || shared_node_bin_resolves "$bin_name"
 }
 
 shared_node_runtime_ready() {

--- a/scripts/tests/node-install-state-guard.sh
+++ b/scripts/tests/node-install-state-guard.sh
@@ -16,6 +16,15 @@ trap cleanup EXIT
 
 mkdir -p "$node_root/.pnpm/node_modules"
 
+cat >"$workspace_root/package.json" <<'JSON'
+{
+  "name": "uiq-install-state-guard-fixture",
+  "private": true,
+  "dependencies": {},
+  "devDependencies": {}
+}
+JSON
+
 cat >"$node_root/.pnpm-workspace-state-v1.json" <<'JSON'
 {
   "projects": {
@@ -53,6 +62,45 @@ cat >"$node_root/.pnpm-workspace-state-v1.json" <<JSON
       "version": "0.1.0"
     }
   }
+}
+JSON
+
+UIQ_NODE_MODULES_DIR="$node_root" uiq_workspace_install_state_ready "$workspace_root"
+
+cat >"$workspace_root/package.json" <<'JSON'
+{
+  "name": "uiq-install-state-guard-fixture",
+  "private": true,
+  "dependencies": {
+    "vitest": "^3.2.4"
+  },
+  "devDependencies": {}
+}
+JSON
+
+set +e
+missing_dep_output="$(
+  UIQ_NODE_MODULES_DIR="$node_root" uiq_workspace_install_state_ready "$workspace_root" 2>&1
+)"
+missing_dep_status=$?
+set -e
+
+if [[ "$missing_dep_status" -eq 0 ]]; then
+  echo "expected missing direct dependency links to fail install-state guard" >&2
+  exit 1
+fi
+
+if ! grep -Fq "missing-direct-dependency-links" <<<"$missing_dep_output"; then
+  echo "expected missing direct dependency reason in guard output" >&2
+  echo "$missing_dep_output" >&2
+  exit 1
+fi
+
+mkdir -p "$node_root/vitest"
+cat >"$node_root/vitest/package.json" <<'JSON'
+{
+  "name": "vitest",
+  "version": "3.2.4"
 }
 JSON
 

--- a/scripts/tests/node-modules-contract-probe.sh
+++ b/scripts/tests/node-modules-contract-probe.sh
@@ -102,4 +102,19 @@ if ! uiq_assert_no_parent_workspace_node_modules "$workspace_root"; then
   exit 1
 fi
 
+if ! uiq_workspace_node_modules_topology_ready "$workspace_root" "$authoritative_root"; then
+  echo "expected canonical workspace node_modules topology to be ready" >&2
+  exit 1
+fi
+
+rm -f "$workspace_root/apps/command-center/node_modules"
+mkdir -p "$workspace_root/apps/command-center/home/runner/work/ui-automation-control-plane/ui-automation-control-plane"
+ln -s ../../../../../../node_modules \
+  "$workspace_root/apps/command-center/home/runner/work/ui-automation-control-plane/ui-automation-control-plane/node_modules"
+
+if uiq_workspace_node_modules_topology_ready "$workspace_root" "$authoritative_root"; then
+  echo "expected corrupted workspace bridge topology to be rejected" >&2
+  exit 1
+fi
+
 echo "node-modules contract probe checks passed"

--- a/scripts/tests/node-modules-contract-probe.sh
+++ b/scripts/tests/node-modules-contract-probe.sh
@@ -92,6 +92,60 @@ fi
 UIQ_NODE_MODULES_DIR="$authoritative_root"
 uiq_link_workspace_node_modules "$workspace_root"
 
+authoritative_export_probe="$(
+  (
+    export RUNNER_TEMP="$runner_temp_root"
+    unset npm_config_modules_dir
+    unset npm_config_virtual_store_dir
+    UIQ_NODE_MODULES_DIR="$authoritative_root"
+    uiq_export_node_env "$workspace_root"
+    printf '%s\n%s\n' "$npm_config_modules_dir" "$npm_config_virtual_store_dir"
+  )
+)"
+
+authoritative_modules_dir="$(printf '%s\n' "$authoritative_export_probe" | sed -n '1p')"
+authoritative_virtual_store_dir="$(printf '%s\n' "$authoritative_export_probe" | sed -n '2p')"
+
+if [[ "$authoritative_modules_dir" != "node_modules" ]]; then
+  echo "expected repo-local authoritative export to keep npm_config_modules_dir project-relative" >&2
+  printf 'actual=%s\n' "$authoritative_modules_dir" >&2
+  exit 1
+fi
+
+if [[ "$authoritative_virtual_store_dir" != "node_modules/.pnpm" ]]; then
+  echo "expected repo-local authoritative export to keep npm_config_virtual_store_dir project-relative" >&2
+  printf 'actual=%s\n' "$authoritative_virtual_store_dir" >&2
+  exit 1
+fi
+
+override_export_probe="$(
+  (
+    export RUNNER_TEMP="$runner_temp_root"
+    unset npm_config_modules_dir
+    unset npm_config_virtual_store_dir
+    UIQ_NODE_MODULES_DIR="$override_root"
+    uiq_export_node_env "$workspace_root"
+    printf '%s\n%s\n' "$npm_config_modules_dir" "$npm_config_virtual_store_dir"
+  )
+)"
+
+override_modules_dir="$(printf '%s\n' "$override_export_probe" | sed -n '1p')"
+override_virtual_store_dir="$(printf '%s\n' "$override_export_probe" | sed -n '2p')"
+normalized_override_root="$(uiq_normalize_abs_path "$override_root")"
+normalized_override_virtual_store_dir="$(uiq_normalize_abs_path "$override_root/.pnpm")"
+
+if [[ "$override_modules_dir" != "$normalized_override_root" ]]; then
+  echo "expected explicit runner-temp bridge export to preserve absolute npm_config_modules_dir" >&2
+  printf 'actual=%s\n' "$override_modules_dir" >&2
+  exit 1
+fi
+
+if [[ "$override_virtual_store_dir" != "$normalized_override_virtual_store_dir" ]]; then
+  echo "expected explicit runner-temp bridge export to preserve absolute npm_config_virtual_store_dir" >&2
+  printf 'actual=%s\n' "$override_virtual_store_dir" >&2
+  exit 1
+fi
+
 if [[ -e "$disallowed_parent_root" || -L "$disallowed_parent_root" ]]; then
   echo "expected repo-local bridge creation to keep parent workspace node_modules absent" >&2
   exit 1


### PR DESCRIPTION
## Summary
- land the reviewer-approved 5-file command-center UI/UX slice
- keep the first-use path focused on Stress Lab -> Runs & Blocks
- include the restart-onboarding blocker fix so launch-first tour steps always reopen on launch

## Validation
- pnpm --dir apps/command-center run test -- src/App.locale-shell.test.tsx src/components/ConsoleHeader.a11y.test.tsx src/components/OnboardingTour.a11y.test.tsx src/views/QuickLaunchView.firstuse.test.tsx src/views/TaskCenterView.a11y.test.tsx src/views/TaskCenterView.waiting-state.test.tsx
- pnpm --dir apps/command-center run lint
- pnpm --dir apps/command-center run build
- git diff --check

## Truth layer
- this PR is only for the new UI/UX first-cut landing
- it is not the old signed replay / PR #20 / PR #21 line