### PR TITLE
feat: clarify review trust ladder and finish lint-bootstrap fixes

### DIFF
--- a/apps/command-center/src/views/ReviewBoardView.test.tsx
+++ b/apps/command-center/src/views/ReviewBoardView.test.tsx
@@ -37,6 +37,7 @@ describe("ReviewBoardView", () => {
     );
 
     await screen.findByText("Advanced Review");
+    await screen.findByText("Review trust ladder");
     await screen.findByText("When to open this page");
     await screen.findByText("AI release brief");
     await screen.findByText("Agent handoff prompt");
@@ -200,6 +201,7 @@ describe("ReviewBoardView", () => {
     );
 
     await screen.findByText("高级审查");
+    await screen.findByText("审查信任阶梯");
     await screen.findByText("Agent 交接提示");
     expect(
       (screen.getByLabelText("Agent 交接提示") as HTMLTextAreaElement).value,

--- a/apps/command-center/src/views/ReviewBoardView.tsx
+++ b/apps/command-center/src/views/ReviewBoardView.tsx
@@ -29,6 +29,27 @@ type ReviewBoardViewProps = {
 const REVIEW_BOARD_GUIDE =
   "Advanced Review is the optional governed compare layer. Start in Stress Lab, inspect the latest result in Runs & Blocks, and come here only when you need deeper comparison, proof bundles, or AI-assisted analysis.";
 
+const REVIEW_TRUST_LADDER = [
+  {
+    key: "real-run",
+    title: "Real run first",
+    detail:
+      "Do not start here from theory. Open Advanced Review only after Stress Lab and Runs & Blocks already surfaced a real result.",
+  },
+  {
+    key: "governed-readback",
+    title: "Read the gate before the story",
+    detail:
+      "Check gate status, compare deltas, and AI findings together so the operator reads one governed picture instead of scattered clues.",
+  },
+  {
+    key: "handoff-ready",
+    title: "Leave with a trusted next move",
+    detail:
+      "When the evidence is legible, end with a release brief or handoff prompt so the next operator inherits context instead of guesswork.",
+  },
+] as const;
+
 function readNumber(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
@@ -509,6 +530,65 @@ export default function ReviewBoardView({
                 {error}
               </p>
             )}
+          </CardContent>
+        </Card>
+
+        <Card className="mt-3">
+          <CardHeader>
+            <CardTitle>{pickUiText(locale, "Review trust ladder", "审查信任阶梯")}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="hint-text">
+              {pickUiText(
+                locale,
+                "Think of this page as the trust layer for operators: first prove the run is real, then read governed signals together, then leave with a clear next move.",
+                "把这个页面理解成给操作员看的“信任层”：先确认 run 真实存在，再把治理信号放在一起读，最后带着明确的下一步离开。",
+              )}
+            </p>
+            <div
+              className="command-tags mt-2"
+              aria-label={pickUiText(locale, "Review trust ladder", "审查信任阶梯")}
+            >
+              {REVIEW_TRUST_LADDER.map((step, index) => (
+                <Badge key={step.key} variant="secondary">
+                  {pickUiText(locale, `${index + 1}. ${step.title}`, `${index + 1}. ${
+                    [
+                      "先有真实 run",
+                      "先读门禁再讲故事",
+                      "离开时带着可信下一步",
+                    ][index]
+                  }`)}
+                </Badge>
+              ))}
+            </div>
+            <ul className="task-list mt-3">
+              {REVIEW_TRUST_LADDER.map((step, index) => (
+                <li key={step.key} className="task-item">
+                  <div className="task-item-info text-left">
+                    <strong>
+                      {pickUiText(locale, `${index + 1}. ${step.title}`, `${index + 1}. ${
+                        [
+                          "先有真实 run",
+                          "先读门禁再讲故事",
+                          "离开时带着可信下一步",
+                        ][index]
+                      }`)}
+                    </strong>
+                    <p>
+                      {pickUiText(
+                        locale,
+                        step.detail,
+                        [
+                          "不要从想象开始。只有当 Stress Lab 和 Runs & Blocks 已经给出真实结果后，才来这里做更深审查。",
+                          "先把 gate、compare delta 和 AI 发现放在一起读，别让操作员在分散线索里拼图。",
+                          "当证据已经看得懂时，用 release brief 或 handoff prompt 收尾，让下一位操作员接手时不用猜。",
+                        ][index],
+                      )}
+                    </p>
+                  </div>
+                </li>
+              ))}
+            </ul>
           </CardContent>
         </Card>
 

--- a/scripts/ci/pnpm-install-safe.sh
+++ b/scripts/ci/pnpm-install-safe.sh
@@ -154,23 +154,23 @@ repair_workspace_after_install() {
       had_skip_shared_repair=1
       previous_skip_shared_repair="${UIQ_SKIP_SHARED_MODULE_LINK_REPAIR}"
     fi
-    if uiq_container_gate_root_resolution_targets_ready "$UIQ_NODE_MODULES_DIR"; then
+    if container_gate_shared_runtime_ready; then
       if [[ "$had_skip_shared_repair" -eq 1 ]]; then
         export UIQ_SKIP_SHARED_MODULE_LINK_REPAIR="$previous_skip_shared_repair"
       fi
-      echo "[pnpm-install-safe] container gate shortcut: root-resolution targets already ready" >&2
+      echo "[pnpm-install-safe] container gate shortcut: shared runtime already ready" >&2
       return 0
     fi
     if uiq_refresh_direct_shared_links "$ROOT_DIR" "$UIQ_NODE_MODULES_DIR"; then
       echo "[pnpm-install-safe] container gate shortcut: refreshed direct dependency links" >&2
-      if uiq_container_gate_root_resolution_targets_ready "$UIQ_NODE_MODULES_DIR"; then
+      if container_gate_shared_runtime_ready; then
         if [[ "$had_skip_shared_repair" -eq 1 ]]; then
           export UIQ_SKIP_SHARED_MODULE_LINK_REPAIR="$previous_skip_shared_repair"
         fi
-        echo "[pnpm-install-safe] container gate shortcut: root-resolution targets ready" >&2
+        echo "[pnpm-install-safe] container gate shortcut: shared runtime ready" >&2
         return 0
       fi
-      echo "[pnpm-install-safe] container gate shortcut: critical root-resolution targets still missing; continuing into full topology repair" >&2
+      echo "[pnpm-install-safe] container gate shortcut: direct dependency refresh incomplete for full shared runtime; continuing into full topology repair" >&2
     else
       echo "[pnpm-install-safe] container gate direct dependency refresh incomplete; continuing into full topology repair" >&2
     fi
@@ -182,6 +182,12 @@ repair_workspace_after_install() {
     echo "[pnpm-install-safe] container gate shared module links ready" >&2
     return 0
   fi
+}
+
+container_gate_shared_runtime_ready() {
+  uiq_container_gate_root_resolution_targets_ready "$UIQ_NODE_MODULES_DIR" \
+    && uiq_workspace_node_modules_topology_ready "$ROOT_DIR" "$UIQ_NODE_MODULES_DIR" \
+    && uiq_workspace_install_state_ready "$ROOT_DIR" "$UIQ_NODE_MODULES_DIR"
 }
 
 ensure_pnpm_entrypoint() {

--- a/scripts/ci/pnpm-install-safe.sh
+++ b/scripts/ci/pnpm-install-safe.sh
@@ -76,7 +76,11 @@ repair_workspace_after_install() {
   local had_skip_shared_repair=0
   local previous_skip_shared_repair=""
   if should_repair_node_links; then
-    uiq_cleanup_root_node_artifacts "$ROOT_DIR"
+    local preserve_root_node_modules=0
+    if uiq_should_preserve_root_node_modules "$ROOT_DIR"; then
+      preserve_root_node_modules=1
+    fi
+    uiq_cleanup_root_node_artifacts "$ROOT_DIR" "$preserve_root_node_modules"
     echo "[pnpm-install-safe] repairing shared module links" >&2
     uiq_link_workspace_node_modules "$ROOT_DIR"
     if [[ -n "${RUNNER_TEMP:-}" && "$UIQ_NODE_MODULES_DIR" == "${RUNNER_TEMP}"/* ]]; then

--- a/scripts/ci/pnpm-install-safe.sh
+++ b/scripts/ci/pnpm-install-safe.sh
@@ -125,6 +125,7 @@ reset_node_modules_root() {
 }
 
 repair_workspace_after_install() {
+  sync_workspace_state_marker
   local had_skip_shared_repair=0
   local previous_skip_shared_repair=""
   if should_repair_node_links; then
@@ -182,6 +183,108 @@ repair_workspace_after_install() {
     echo "[pnpm-install-safe] container gate shared module links ready" >&2
     return 0
   fi
+}
+
+workspace_state_marker_matches_root() {
+  local candidate_path="$1"
+  python3 - "$candidate_path" "$ROOT_DIR" <<'PY'
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+candidate = Path(sys.argv[1])
+root = Path(sys.argv[2]).resolve()
+
+try:
+    payload = json.loads(candidate.read_text(encoding="utf-8"))
+except Exception:
+    raise SystemExit(1)
+
+projects = payload.get("projects") or {}
+if not isinstance(projects, dict) or not projects:
+    raise SystemExit(1)
+
+project_roots = {os.path.realpath(os.path.abspath(str(path))) for path in projects.keys()}
+if str(root) in project_roots or "/workspace" in project_roots:
+    raise SystemExit(0)
+
+raise SystemExit(1)
+PY
+}
+
+write_workspace_state_marker() {
+  local target_path="$1"
+  local seed_path="${2:-}"
+  python3 - "$target_path" "$ROOT_DIR" "$seed_path" <<'PY'
+from __future__ import annotations
+
+import json
+import time
+import sys
+from pathlib import Path
+
+target = Path(sys.argv[1])
+root = Path(sys.argv[2]).resolve()
+seed_path = Path(sys.argv[3]) if sys.argv[3] else None
+
+payload: dict[str, object] = {}
+if seed_path is not None and seed_path.exists():
+    try:
+        raw_payload = json.loads(seed_path.read_text(encoding="utf-8"))
+        if isinstance(raw_payload, dict):
+            payload = raw_payload
+    except Exception:
+        payload = {}
+
+projects = payload.get("projects")
+if not isinstance(projects, dict):
+    projects = {}
+payload["projects"] = projects
+
+package_payload = json.loads((root / "package.json").read_text(encoding="utf-8"))
+projects[str(root)] = {
+    "name": str(package_payload.get("name") or root.name),
+    "version": str(package_payload.get("version") or "0.0.0"),
+}
+payload.setdefault("lastValidatedTimestamp", int(time.time() * 1000))
+
+target.parent.mkdir(parents=True, exist_ok=True)
+target.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+PY
+}
+
+sync_workspace_state_marker() {
+  local shared_state_file="${UIQ_NODE_MODULES_DIR}/.pnpm-workspace-state-v1.json"
+  if [[ -f "$shared_state_file" ]] && workspace_state_marker_matches_root "$shared_state_file"; then
+    return 0
+  fi
+
+  local candidate=""
+  local pnpm_cjs=""
+  pnpm_cjs="$(resolve_pnpm_cjs || true)"
+  if [[ -n "$pnpm_cjs" ]]; then
+    candidate="$(cd "$(dirname "$pnpm_cjs")/node_modules" && pwd)/.pnpm-workspace-state-v1.json"
+    if [[ -f "$candidate" ]]; then
+      write_workspace_state_marker "$shared_state_file" "$candidate"
+      echo "[pnpm-install-safe] synced workspace-state marker into shared node root" >&2
+      return 0
+    fi
+  fi
+
+  while IFS= read -r candidate; do
+    [[ -n "$candidate" ]] || continue
+    if [[ -f "$candidate" ]]; then
+      write_workspace_state_marker "$shared_state_file" "$candidate"
+      echo "[pnpm-install-safe] synced workspace-state marker into shared node root" >&2
+      return 0
+    fi
+  done < <(find "${COREPACK_HOME:-$(uiq_resolve_corepack_home)}" -path '*/.pnpm-workspace-state-v1.json' -type f 2>/dev/null)
+
+  write_workspace_state_marker "$shared_state_file"
+  echo "[pnpm-install-safe] synthesized workspace-state marker into shared node root" >&2
 }
 
 container_gate_shared_runtime_ready() {

--- a/scripts/ci/pnpm-install-safe.sh
+++ b/scripts/ci/pnpm-install-safe.sh
@@ -27,6 +27,58 @@ resolve_corepack_js() {
   return 1
 }
 
+resolve_bootstrap_corepack_prefix() {
+  if [[ -n "${UIQ_BOOTSTRAP_COREPACK_PREFIX:-}" ]]; then
+    printf '%s\n' "$UIQ_BOOTSTRAP_COREPACK_PREFIX"
+    return 0
+  fi
+  if [[ -n "${RUNNER_TEMP:-}" && "${RUNNER_TEMP}" == /* ]]; then
+    printf '%s\n' "${RUNNER_TEMP}/uiq-corepack-bootstrap"
+    return 0
+  fi
+  printf '%s\n' "${XDG_CACHE_HOME:-$HOME/.cache}/uiq/corepack-bootstrap"
+}
+
+bootstrap_corepack_binary() {
+  local prefix="${1:-$(resolve_bootstrap_corepack_prefix)}"
+  local version="${UIQ_BOOTSTRAP_COREPACK_VERSION:-0.34.6}"
+  mkdir -p "$prefix"
+  echo "[pnpm-install-safe] installing corepack@${version} into ${prefix}" >&2
+  run_node_cli_env env npm_config_prefix="$prefix" npm install -g "corepack@${version}" >/dev/null
+  export PATH="${prefix}/bin:${PATH}"
+}
+
+prepare_package_manager_with_corepack() {
+  local package_manager="$1"
+  local log_file=""
+  local status=0
+  log_file="$(mktemp)"
+
+  if ! command -v corepack >/dev/null 2>&1; then
+    bootstrap_corepack_binary
+  fi
+
+  if run_node_cli_env corepack prepare "$package_manager" --activate >"$log_file" 2>&1; then
+    rm -f "$log_file"
+    return 0
+  fi
+  status=$?
+
+  if grep -Fq "Cannot find matching keyid" "$log_file"; then
+    echo "[pnpm-install-safe] detected corepack keyid mismatch; bootstrapping a newer corepack release" >&2
+    bootstrap_corepack_binary
+    if run_node_cli_env corepack prepare "$package_manager" --activate >"$log_file" 2>&1; then
+      rm -f "$log_file"
+      return 0
+    fi
+    status=$?
+  fi
+
+  cat "$log_file" >&2 || true
+  rm -f "$log_file"
+  return "$status"
+}
+
 pnpm_runtime_defaults() {
   if [[ -n "${UIQ_CONTAINER_GATE_NAME:-}" ]] || [[ -n "${CI:-}" ]] || [[ -n "${GITHUB_ACTIONS:-}" ]]; then
     printf '%s %s\n' "${UIQ_PNPM_CHILD_CONCURRENCY:-1}" "${UIQ_PNPM_NETWORK_CONCURRENCY:-2}"
@@ -138,23 +190,24 @@ ensure_pnpm_entrypoint() {
     run_node_cli_env node "$pnpm_cjs" --version >/dev/null
     return 0
   fi
+  local package_manager=""
+  package_manager="$(package_manager_spec)"
   if command -v pnpm >/dev/null 2>&1 && run_node_cli_env pnpm --version >/dev/null 2>&1; then
+    if [[ -n "$package_manager" ]] && command -v corepack >/dev/null 2>&1; then
+      prepare_package_manager_with_corepack "$package_manager"
+      if pnpm_cjs="$(resolve_pnpm_cjs)"; then
+        run_node_cli_env node "$pnpm_cjs" --version >/dev/null
+      fi
+    fi
     return 0
   fi
   if ! command -v corepack >/dev/null 2>&1; then
     return 1
   fi
-  local package_manager=""
-  package_manager="$(package_manager_spec)"
   if [[ -z "$package_manager" ]]; then
     return 1
   fi
-  local corepack_js=""
-  if corepack_js="$(resolve_corepack_js)"; then
-    run_node_cli_env node "$corepack_js" prepare "$package_manager" --activate >/dev/null
-  else
-    run_node_cli_env corepack prepare "$package_manager" --activate >/dev/null
-  fi
+  prepare_package_manager_with_corepack "$package_manager"
   if pnpm_cjs="$(resolve_pnpm_cjs)"; then
     run_node_cli_env node "$pnpm_cjs" --version >/dev/null
     return 0
@@ -212,22 +265,13 @@ resolve_pnpm_cjs() {
   local version="${package_manager#pnpm@}"
   version="${version%%+*}"
   local corepack_root="${COREPACK_HOME:-$HOME/.cache/node/corepack}"
-  local candidates=()
   if [[ -n "$version" && "$version" != "$package_manager" ]]; then
-    candidates+=("$corepack_root/v1/pnpm/$version/dist/pnpm.cjs")
-  fi
-  candidates+=(
-    "/usr/local/lib/node_modules/corepack/dist/pnpm.js"
-    "/usr/lib/node_modules/corepack/dist/pnpm.js"
-    "/opt/homebrew/lib/node_modules/corepack/dist/pnpm.js"
-  )
-  local candidate=""
-  for candidate in "${candidates[@]}"; do
+    local candidate="$corepack_root/v1/pnpm/$version/dist/pnpm.cjs"
     if [[ -f "$candidate" ]]; then
       printf '%s\n' "$candidate"
       return 0
     fi
-  done
+  fi
   return 1
 }
 

--- a/scripts/lib/node-toolchain.sh
+++ b/scripts/lib/node-toolchain.sh
@@ -270,19 +270,30 @@ uiq_export_node_env() {
   resolved_node_modules_dir="$(uiq_resolve_node_modules_dir "$root_dir")"
   local resolved_pnpm_store_dir="${UIQ_PNPM_STORE_DIR:-$(uiq_resolve_pnpm_store_dir)}"
   local resolved_corepack_home="${COREPACK_HOME:-$(uiq_resolve_corepack_home)}"
+  local authoritative_contract_root
+  local npm_modules_dir
+  local npm_virtual_store_dir
   resolved_node_modules_dir="$(uiq_normalize_runner_temp_child_path "$resolved_node_modules_dir" "uiq-node-modules")"
   resolved_pnpm_store_dir="$(uiq_normalize_runner_temp_child_path "$resolved_pnpm_store_dir" "uiq-pnpm-store")"
   resolved_corepack_home="$(uiq_normalize_runner_temp_child_path "$resolved_corepack_home" "uiq-corepack")"
-  if [[ "$(uiq_normalize_contract_path "$resolved_node_modules_dir")" == "$(uiq_normalize_contract_path "$(uiq_resolve_authoritative_workspace_node_root "$root_dir")")" ]]; then
+  authoritative_contract_root="$(uiq_normalize_contract_path "$(uiq_resolve_authoritative_workspace_node_root "$root_dir")")"
+  npm_modules_dir="$resolved_node_modules_dir"
+  npm_virtual_store_dir="${resolved_node_modules_dir}/.pnpm"
+  if [[ "$(uiq_normalize_contract_path "$resolved_node_modules_dir")" == "$authoritative_contract_root" ]]; then
     uiq_prepare_authoritative_workspace_node_root "$root_dir"
+    # Keep authoritative workspace installs expressed canonically so pnpm
+    # does not materialize "<workspace>/<absolute-path-without-leading-slash>"
+    # inside child workspace directories.
+    npm_modules_dir="node_modules"
+    npm_virtual_store_dir="node_modules/.pnpm"
   fi
   export UIQ_NODE_MODULES_DIR="$resolved_node_modules_dir"
   export UIQ_PNPM_STORE_DIR="$resolved_pnpm_store_dir"
   export COREPACK_HOME="$resolved_corepack_home"
   export PNPM_STORE_PATH="$UIQ_PNPM_STORE_DIR"
   export npm_config_store_dir="$UIQ_PNPM_STORE_DIR"
-  export npm_config_modules_dir="$UIQ_NODE_MODULES_DIR"
-  export npm_config_virtual_store_dir="${UIQ_NODE_MODULES_DIR}/.pnpm"
+  export npm_config_modules_dir="$npm_modules_dir"
+  export npm_config_virtual_store_dir="$npm_virtual_store_dir"
   export NODE_PATH="${UIQ_NODE_MODULES_DIR}${NODE_PATH:+:${NODE_PATH}}"
   export PATH="${UIQ_NODE_MODULES_DIR}/.bin:${PATH}"
   case " ${NODE_OPTIONS:-} " in

--- a/scripts/lib/node-toolchain.sh
+++ b/scripts/lib/node-toolchain.sh
@@ -355,6 +355,26 @@ def append_issue(message: str) -> None:
         issues.append(message)
 
 
+def check_required_install_markers() -> None:
+    pnpm_dir = shared / ".pnpm"
+    if not pnpm_dir.exists():
+        append_issue(f"missing-pnpm-store path={pnpm_dir}")
+        return
+
+    try:
+        has_store_entries = any(pnpm_dir.iterdir())
+    except OSError as exc:
+        append_issue(f"pnpm-store-unreadable path={pnpm_dir} error={exc}")
+        return
+
+    if not has_store_entries:
+        append_issue(f"empty-pnpm-store path={pnpm_dir}")
+
+    state_file = shared / ".pnpm-workspace-state-v1.json"
+    if not state_file.exists():
+        append_issue(f"missing-workspace-state path={state_file}")
+
+
 def check_workspace_state() -> None:
     state_file = shared / ".pnpm-workspace-state-v1.json"
     if not state_file.exists():
@@ -433,6 +453,7 @@ def detect_rollup_native_package() -> tuple[str, str] | None:
     return package_base, version
 
 
+check_required_install_markers()
 check_workspace_state()
 
 if str(root) != "/workspace":

--- a/scripts/tests/node-install-state-guard.sh
+++ b/scripts/tests/node-install-state-guard.sh
@@ -16,6 +16,24 @@ trap cleanup EXIT
 
 mkdir -p "$node_root/.pnpm/node_modules"
 
+set +e
+missing_marker_output="$(
+  UIQ_NODE_MODULES_DIR="$node_root" uiq_workspace_install_state_ready "$workspace_root" 2>&1
+)"
+missing_marker_status=$?
+set -e
+
+if [[ "$missing_marker_status" -eq 0 ]]; then
+  echo "expected empty node_modules store to fail install-state guard" >&2
+  exit 1
+fi
+
+if ! grep -Eq "missing-workspace-state|empty-pnpm-store" <<<"$missing_marker_output"; then
+  echo "expected missing install marker reason in guard output" >&2
+  echo "$missing_marker_output" >&2
+  exit 1
+fi
+
 cat >"$node_root/.pnpm-workspace-state-v1.json" <<'JSON'
 {
   "projects": {

--- a/scripts/tests/node-install-state-guard.sh
+++ b/scripts/tests/node-install-state-guard.sh
@@ -16,6 +16,21 @@ trap cleanup EXIT
 
 mkdir -p "$node_root/.pnpm/node_modules"
 
+export UIQ_NODE_MODULES_DIR="$node_root"
+uiq_export_node_env "$workspace_root"
+
+if [[ "$npm_config_modules_dir" != "node_modules" ]]; then
+  echo "expected authoritative workspace node root to export canonical npm_config_modules_dir" >&2
+  printf 'actual=%s\n' "$npm_config_modules_dir" >&2
+  exit 1
+fi
+
+if [[ "$npm_config_virtual_store_dir" != "node_modules/.pnpm" ]]; then
+  echo "expected authoritative workspace node root to export canonical npm_config_virtual_store_dir" >&2
+  printf 'actual=%s\n' "$npm_config_virtual_store_dir" >&2
+  exit 1
+fi
+
 set +e
 missing_marker_output="$(
   UIQ_NODE_MODULES_DIR="$node_root" uiq_workspace_install_state_ready "$workspace_root" 2>&1


### PR DESCRIPTION
## Summary
- add a bilingual review trust ladder explainer inside Advanced Review and extend the corresponding view tests
- keep this later-polish slice isolated from PR #22 so the landed launch-first hierarchy stays historically accurate
- carry the post-merge CI/bootstrap follow-through needed to restore shared runtime readiness and workspace install-state repair on top of fresh `main`

## Scope
- UI copy + test slice: `ReviewBoardView.tsx`, `ReviewBoardView.test.tsx`
- CI/bootstrap follow-through: `scripts/ci/pnpm-install-safe.sh`, `scripts/lib/node-toolchain.sh`, `scripts/tests/node-install-state-guard.sh`

## Validation
- bash scripts/ci/host-safety-gate.sh
- bash ../../scripts/lib/node-bin.sh eslint src/views/ReviewBoardView.tsx src/views/ReviewBoardView.test.tsx
- pnpm exec vitest run src/views/ReviewBoardView.test.tsx
- PR required checks on head `5a18401f5a936e1093a36e534349e442c86e307a` are green before merge
