### PR TITLE
chore: rename top-level manifest to browserclickyard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ui-automation-control-plane",
+  "name": "browserclickyard",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "ui-automation-control-plane"
+name = "browserclickyard"
 version = "0.1.0"
 description = "Automation scaffold with FastAPI backend and browser/API testing support"
 readme = "README.md"


### PR DESCRIPTION
Sync top-level manifest `name` field to match the new GitHub repo name **browserclickyard**.

Part of the 17-repo brand-rename plan (-yard / Open- / *Me families).